### PR TITLE
New noble gas solubilities etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ panga.app/Contents/MacOS/panga
 *~
 *.kate-swp
 .directory
+.vscode

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,9 +32,13 @@ set(core_SOURCES
     models/derivativecollector.cpp
     models/diffusioncoefficientinair.cpp
     models/modelmanager.cpp
+    models/ceqmethodmanager.cpp
     models/parametermanager.cpp
     models/physicalproperties.cpp
     models/weissmethod.cpp
+    models/weissmethodfactory.cpp
+    models/jenkinsmethod.cpp
+    models/jenkinsmethodfactory.cpp
     misc/rundata.cpp
  
     models/cemodel.cpp

--- a/src/core/fitting/fitresults.h
+++ b/src/core/fitting/fitresults.h
@@ -38,7 +38,7 @@ class FitResults
 
 public:
 
-    FitResults() : chi_square(-1.), n_iterations(0) {}
+    FitResults() : chi_square(-1.), n_iterations(0) {} //WIP???
 
     virtual ~FitResults() {}
 

--- a/src/core/fitting/fitresults.h
+++ b/src/core/fitting/fitresults.h
@@ -38,7 +38,7 @@ class FitResults
 
 public:
 
-    FitResults() : chi_square(-1.), n_iterations(0) {} //WIP???
+    FitResults() : chi_square(-1.), n_iterations(0) {}
 
     virtual ~FitResults() {}
 

--- a/src/core/fitting/levenbergmarquardtfitter.cpp
+++ b/src/core/fitting/levenbergmarquardtfitter.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<FitResults> LevenbergMarquardtFitter::fit(
         {
             Eigen::covar(lm.fjac, lm.permutation.indices(),
                          std::numeric_limits<double>::epsilon());
-            results->covariance_matrix =
+            results->covariance_matrix = //WIP1: Sind die für alle Parameter drin?
                     lm.fjac.topLeftCorner(n_params, n_params);
             results->residuals = lm.fvec;
         }
@@ -133,7 +133,7 @@ std::shared_ptr<FitResults> LevenbergMarquardtFitter::fit(
         }
         
         results->best_estimate = x;
-        results->deviations = results->covariance_matrix.diagonal().cwiseSqrt();
+        results->deviations = results->covariance_matrix.diagonal().cwiseSqrt(); //WIP1: Sind die für alle Parameter drin?
         results->chi_square =
                 results->residuals.cwiseProduct(results->residuals).sum();
         results->degrees_of_freedom = n_values - n_params;

--- a/src/core/fitting/levenbergmarquardtfitter.cpp
+++ b/src/core/fitting/levenbergmarquardtfitter.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<FitResults> LevenbergMarquardtFitter::fit(
         {
             Eigen::covar(lm.fjac, lm.permutation.indices(),
                          std::numeric_limits<double>::epsilon());
-            results->covariance_matrix = //WIP1: Sind die für alle Parameter drin?
+            results->covariance_matrix = 
                     lm.fjac.topLeftCorner(n_params, n_params);
             results->residuals = lm.fvec;
         }
@@ -133,7 +133,7 @@ std::shared_ptr<FitResults> LevenbergMarquardtFitter::fit(
         }
         
         results->best_estimate = x;
-        results->deviations = results->covariance_matrix.diagonal().cwiseSqrt(); //WIP1: Sind die für alle Parameter drin?
+        results->deviations = results->covariance_matrix.diagonal().cwiseSqrt(); 
         results->chi_square =
                 results->residuals.cwiseProduct(results->residuals).sum();
         results->degrees_of_freedom = n_values - n_params;

--- a/src/core/models/ceqcalculationmethod.h
+++ b/src/core/models/ceqcalculationmethod.h
@@ -16,7 +16,7 @@
 // along with Panga.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#ifndef CEQCALCULATIONMETHOD_H
+#ifndef CEQCALCULATIONMETHOD_H //WIP: Makro? Bedeutung prüfen
 #define CEQCALCULATIONMETHOD_H
 
 #include <memory>
@@ -80,6 +80,8 @@ public:
         std::shared_ptr<DerivativeCollector> derivatives,
         GasType gas
         ) const = 0;
+
+    virtual std::string GetCEqMethodName() const = 0; //WIP: Notwendig?
 };
 
 #endif // CEQCALCULATIONMETHOD_H

--- a/src/core/models/ceqcalculationmethod.h
+++ b/src/core/models/ceqcalculationmethod.h
@@ -16,7 +16,7 @@
 // along with Panga.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#ifndef CEQCALCULATIONMETHOD_H //WIP: Makro? Bedeutung prüfen
+#ifndef CEQCALCULATIONMETHOD_H
 #define CEQCALCULATIONMETHOD_H
 
 #include <memory>
@@ -82,7 +82,7 @@ public:
         GasType gas
         ) const = 0;
 
-    virtual std::string GetCEqMethodName() const = 0; //WIP: Notwendig?
+    virtual std::string GetCEqMethodName() const = 0;
 };
 
 #endif // CEQCALCULATIONMETHOD_H

--- a/src/core/models/ceqcalculationmethod.h
+++ b/src/core/models/ceqcalculationmethod.h
@@ -37,6 +37,7 @@ class CEqCalculationMethod
 {
 
 public:
+    CEqCalculationMethod(){}
 
     //! Destruktor.
     virtual ~CEqCalculationMethod() {}

--- a/src/core/models/ceqmethodfactory.h
+++ b/src/core/models/ceqmethodfactory.h
@@ -1,0 +1,47 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef CEQMETHODFACTORY_H //WIP: Was ist das?
+#define CEQMETHODFACTORY_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/misc/parameter_description.h"
+#include "core/models/parametermanager.h"
+
+#include "ceqcalculationmethod.h"
+
+//! Muss von Plugins zum Erzeugen von Methoden bereitgestellt werden.
+class CEqMethodFactory
+{
+
+public:
+
+    virtual ~CEqMethodFactory() {}
+
+    //! Erzeugt die Methode.
+    virtual std::shared_ptr<CEqCalculationMethod> CreateCEqMethod( 
+        std::shared_ptr<ParameterManager> manager
+        ) const = 0;
+
+    virtual std::string GetCEqMethodName() const = 0;
+};
+
+#endif // CEQMETHODFACTORY_H

--- a/src/core/models/ceqmethodfactory.h
+++ b/src/core/models/ceqmethodfactory.h
@@ -16,7 +16,7 @@
 // along with Panga.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#ifndef CEQMETHODFACTORY_H //WIP: Was ist das?
+#ifndef CEQMETHODFACTORY_H
 #define CEQMETHODFACTORY_H
 
 #include <memory>

--- a/src/core/models/ceqmethodmanager.cpp
+++ b/src/core/models/ceqmethodmanager.cpp
@@ -1,0 +1,83 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include <QApplication>
+#include <QDir>
+#include <QPluginLoader>
+
+#include <boost/bind.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "weissmethodfactory.h"
+#include "jenkinsmethodfactory.h"
+
+// #include "cemodelfactory.h"
+// #include "grmodelfactory.h"
+// #include "odmodelfactory.h"
+// #include "pdmodelfactory.h"
+// #include "prmodelfactory.h"
+// #include "uamodelfactory.h"
+
+#include "ceqmethodmanager.h"
+
+const std::vector<std::shared_ptr<CEqMethodFactory>> CEqMethodManager::CEQMETHOD_FACTORIES =
+    {// std::make_shared<CeModelFactory>(),
+    //  std::make_shared<GrModelFactory>(),
+    //  std::make_shared<OdModelFactory>(),
+    //  std::make_shared<PdModelFactory>(),
+    //  std::make_shared<PrModelFactory>(),
+     std::make_shared<WeissMethodFactory>(),
+     std::make_shared<JenkinsMethodFactory>()
+     };
+
+const CEqMethodManager& CEqMethodManager::Get()
+{
+    static CEqMethodManager manager;  //WIP: Wieso kein Konstuktor?
+    return manager;
+}
+
+CEqMethodManager::CEqMethodManager()
+{
+    for (auto factory : CEQMETHOD_FACTORIES)
+        ceqmethod_factories_[factory->GetCEqMethodName()] = factory.get(); //WIP: Woher kommt get?
+}
+
+CEqMethodFactory* CEqMethodManager::GetCEqMethodFactory(const std::string &name) const
+{
+    MapType::const_iterator it;
+
+    it = ceqmethod_factories_.find(name);
+
+    if (it == ceqmethod_factories_.end())
+        throw CEqMethodNotFoundError();
+
+    return it->second;
+}
+
+std::vector<std::string> CEqMethodManager::GetAvailableCEqMethods() const
+{
+    std::vector<std::string> ret;
+
+    std::transform(ceqmethod_factories_.begin(), ceqmethod_factories_.end(),
+                   std::back_inserter(ret),
+                   boost::bind(&MapType::value_type::first, _1));
+
+    return ret;
+}

--- a/src/core/models/ceqmethodmanager.cpp
+++ b/src/core/models/ceqmethodmanager.cpp
@@ -37,13 +37,10 @@
 
 #include "ceqmethodmanager.h"
 
+//WIP: Achtung: Die Methoden werden in FitSetup::SetModel über GetCEqMethodFactory(const std::string &name) nach ihren Namen ausgewählt.
+//     Namen, die Teilmengen anderer Namen sind können darüber nicht eindeutig zugeordnet werden.
 const std::vector<std::shared_ptr<CEqMethodFactory>> CEqMethodManager::CEQMETHOD_FACTORIES =
-    {// std::make_shared<CeModelFactory>(),
-    //  std::make_shared<GrModelFactory>(),
-    //  std::make_shared<OdModelFactory>(),
-    //  std::make_shared<PdModelFactory>(),
-    //  std::make_shared<PrModelFactory>(),
-     std::make_shared<WeissMethodFactory>(),
+    {std::make_shared<WeissMethodFactory>(),
      std::make_shared<JenkinsMethodFactory>()
      };
 

--- a/src/core/models/ceqmethodmanager.cpp
+++ b/src/core/models/ceqmethodmanager.cpp
@@ -37,8 +37,8 @@
 
 #include "ceqmethodmanager.h"
 
-//WIP: Achtung: Die Methoden werden in FitSetup::SetModel über GetCEqMethodFactory(const std::string &name) nach ihren Namen ausgewählt.
-//     Namen, die Teilmengen anderer Namen sind können darüber nicht eindeutig zugeordnet werden.
+// Achtung: Die Methoden werden in FitSetup::SetModel über GetCEqMethodFactory(const std::string &name) nach ihren Namen ausgewählt.
+// Namen, die Teilmengen anderer Namen sind können darüber nicht eindeutig zugeordnet werden.
 const std::vector<std::shared_ptr<CEqMethodFactory>> CEqMethodManager::CEQMETHOD_FACTORIES =
     {std::make_shared<WeissMethodFactory>(),
      std::make_shared<JenkinsMethodFactory>()
@@ -46,14 +46,14 @@ const std::vector<std::shared_ptr<CEqMethodFactory>> CEqMethodManager::CEQMETHOD
 
 const CEqMethodManager& CEqMethodManager::Get()
 {
-    static CEqMethodManager manager;  //WIP: Wieso kein Konstuktor?
+    static CEqMethodManager manager;
     return manager;
 }
 
 CEqMethodManager::CEqMethodManager()
 {
     for (auto factory : CEQMETHOD_FACTORIES)
-        ceqmethod_factories_[factory->GetCEqMethodName()] = factory.get(); //WIP: Woher kommt get?
+        ceqmethod_factories_[factory->GetCEqMethodName()] = factory.get();
 }
 
 CEqMethodFactory* CEqMethodManager::GetCEqMethodFactory(const std::string &name) const

--- a/src/core/models/ceqmethodmanager.h
+++ b/src/core/models/ceqmethodmanager.h
@@ -1,0 +1,71 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef CEQMETHODMANAGER_H
+#define CEQMETHODMANAGER_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ceqmethodfactory.h"
+
+//! Lädt Modelle aus dem plugins-Unterverzeichnis und erstellt sie bei Bedarf.
+/*!
+ * \todo Die gesamte Modellerstellung gehört refaktorisiert, zumindest diese
+ * Klasse.
+ * 
+ * Singleton.
+ */
+class CEqMethodManager
+{
+
+public:
+
+    //! Gibt den PluginManager zurück.
+    static const CEqMethodManager& Get();
+    
+    //! Gibt die gewünschte ModelFactory zurück.
+    /*!
+      \param name Name des Modells.
+      \return Zeiger auf die ModelFactory.
+      */
+    CEqMethodFactory* GetCEqMethodFactory(const std::string& name) const;
+
+    //! Erzeugt eine Liste aller verfügbaren Modelle.
+    std::vector<std::string> GetAvailableCEqMethods() const;
+    
+    class CEqMethodNotFoundError {};
+
+
+private:
+
+    //! Konstruiert das Objekt und lädt alle Modelle aus dem plugins-Unterverzeichnis.
+    CEqMethodManager();
+    CEqMethodManager(const CEqMethodManager&) = delete;
+    CEqMethodManager& operator=(const CEqMethodManager&) = delete;
+    
+    typedef std::map<std::string, CEqMethodFactory*> MapType;
+    //! Map mit Zeigern auf alle verfügbaren Modelle.
+    MapType ceqmethod_factories_;
+
+    static const std::vector<std::shared_ptr<CEqMethodFactory>> CEQMETHOD_FACTORIES;
+};
+
+#endif // CEQMETHODMANAGER_H

--- a/src/core/models/clevermethod.cpp
+++ b/src/core/models/clevermethod.cpp
@@ -130,7 +130,7 @@ double CleverMethod::CalculateConcentration(double p, double S, double T, GasTyp
            PhysicalProperties::GetMolarVolume(gas) *
 
             // Partialdruck der trockenen Luft                      * Xe-Anteil
-           (p - PhysicalProperties::CalcSaturationVaporPressure_Gill(T)) * z_ *
+           (p - PhysicalProperties::CalcSaturationVaporPressure_Dickson(T, S)) * z_ *
 
            PhysicalProperties::CalcWaterDensity(1., 0., T) /
            PhysicalProperties::CalcWaterDensity(1., S , T) *

--- a/src/core/models/clevermethod.cpp
+++ b/src/core/models/clevermethod.cpp
@@ -25,6 +25,13 @@
 
 #include "clevermethod.h"
 
+const std::string CleverMethod::NAME = "Weiss,Clever(Xe)";  //WIP: Neu, verwendet?
+
+std::string CleverMethod::GetCEqMethodName() const  //WIP: Neu, verwendet?
+{
+    return CleverMethod::NAME;
+}
+
 CleverMethod::CleverMethod(std::shared_ptr<ParameterManager> manager)
 {
     RegisterParameters(manager,

--- a/src/core/models/clevermethod.cpp
+++ b/src/core/models/clevermethod.cpp
@@ -25,9 +25,9 @@
 
 #include "clevermethod.h"
 
-const std::string CleverMethod::NAME = "Weiss,Clever(Xe)";  //WIP: Neu, verwendet?
+const std::string CleverMethod::NAME = "Clever(Xe)"; 
 
-std::string CleverMethod::GetCEqMethodName() const  //WIP: Neu, verwendet?
+std::string CleverMethod::GetCEqMethodName() const
 {
     return CleverMethod::NAME;
 }

--- a/src/core/models/clevermethod.cpp
+++ b/src/core/models/clevermethod.cpp
@@ -126,7 +126,6 @@ double CleverMethod::CalculateConcentration(double p, double S, double T, GasTyp
            // Molmasse von Wasser [g/mol]
            18.016 *
 
-           // Molvolumen aus Kipfer et al. 2002
            PhysicalProperties::GetMolarVolume(gas) *
 
             // Partialdruck der trockenen Luft                      * Xe-Anteil

--- a/src/core/models/clevermethod.cpp
+++ b/src/core/models/clevermethod.cpp
@@ -130,7 +130,7 @@ double CleverMethod::CalculateConcentration(double p, double S, double T, GasTyp
            PhysicalProperties::GetMolarVolume(gas) *
 
             // Partialdruck der trockenen Luft                      * Xe-Anteil
-           (p - PhysicalProperties::CalcSaturationVaporPressure(T)) * z_ *
+           (p - PhysicalProperties::CalcSaturationVaporPressure_Gill(T)) * z_ *
 
            PhysicalProperties::CalcWaterDensity(1., 0., T) /
            PhysicalProperties::CalcWaterDensity(1., S , T) *

--- a/src/core/models/clevermethod.cpp
+++ b/src/core/models/clevermethod.cpp
@@ -127,7 +127,7 @@ double CleverMethod::CalculateConcentration(double p, double S, double T, GasTyp
            18.016 *
 
            // Molvolumen aus Kipfer et al. 2002
-           22280.4 *
+           PhysicalProperties::GetMolarVolume(gas) *
 
             // Partialdruck der trockenen Luft                      * Xe-Anteil
            (p - PhysicalProperties::CalcSaturationVaporPressure(T)) * z_ *

--- a/src/core/models/clevermethod.h
+++ b/src/core/models/clevermethod.h
@@ -51,7 +51,7 @@
   \f$X_i\f$: \ref PhysicalProperties::CalcXeMoleFractionSolubility "Mole fraction solubility des Gases"
     (einheitenlos).\n
   \f$M_{H_2O}\f$: Molmasse von Wasser.\n
-  \f$e_w\f$: \ref PhysicalProperties::CalcSaturationVaporPressure "Sättigungsdampfdruck des Wassers".\n
+  \f$e_w\f$: \ref PhysicalProperties::CalcSaturationVaporPressure_Gill "Sättigungsdampfdruck des Wassers".\n
   \f$z_i\f$: Volumen-Anteil des Gases in trockener Luft.\n
   \f$\rho(T,S)\f$: \ref PhysicalProperties::CalcWaterDensity "Dichte des Wassers".\n
   \f$V_i\f$: Molvolumen des Gases.\n

--- a/src/core/models/clevermethod.h
+++ b/src/core/models/clevermethod.h
@@ -96,6 +96,10 @@ public:
                                          double T,
                                          GasType gas);
 
+    static const std::string NAME;
+    
+    std::string GetCEqMethodName() const; //WIP: Verwendet?
+
 private:
     //! Volumen-Anteil von Xe in trockener Luft.
     static const double z_;

--- a/src/core/models/clevermethod.h
+++ b/src/core/models/clevermethod.h
@@ -51,7 +51,7 @@
   \f$X_i\f$: \ref PhysicalProperties::CalcXeMoleFractionSolubility "Mole fraction solubility des Gases"
     (einheitenlos).\n
   \f$M_{H_2O}\f$: Molmasse von Wasser.\n
-  \f$e_w\f$: \ref PhysicalProperties::CalcSaturationVaporPressure_Gill "Sättigungsdampfdruck des Wassers".\n
+  \f$e_w\f$: \ref PhysicalProperties::CalcSaturationVaporPressure_Dickson "Sättigungsdampfdruck des Wassers".\n
   \f$z_i\f$: Volumen-Anteil des Gases in trockener Luft.\n
   \f$\rho(T,S)\f$: \ref PhysicalProperties::CalcWaterDensity "Dichte des Wassers".\n
   \f$V_i\f$: Molvolumen des Gases.\n

--- a/src/core/models/clevermethod.h
+++ b/src/core/models/clevermethod.h
@@ -98,7 +98,7 @@ public:
 
     static const std::string NAME;
     
-    std::string GetCEqMethodName() const; //WIP: Verwendet?
+    std::string GetCEqMethodName() const;
 
 private:
     //! Volumen-Anteil von Xe in trockener Luft.

--- a/src/core/models/combinedmodel.cpp
+++ b/src/core/models/combinedmodel.cpp
@@ -149,6 +149,11 @@ std::string CombinedModel::GetExcessAirModelName() const //WIP: Auch noch für M
     return  model_->GetModelName();
 }
 
+std::string CombinedModel::GetCEqMethodName() const 
+{
+    return  ceqmethod_->GetCEqMethodName();
+}
+
 void CombinedModel::SetApplyConstraints(bool apply)
 {
     model_->SetApplyConstraints(apply);

--- a/src/core/models/combinedmodel.cpp
+++ b/src/core/models/combinedmodel.cpp
@@ -20,8 +20,9 @@
 
 #include "combinedmodel.h"
 
-CombinedModel::CombinedModel(ModelFactory* factory) :
+CombinedModel::CombinedModel(ModelFactory* factory, ModelFactory* ceqmethod_factory=nullptr) :
     factory_(factory),
+    ceqmethod_factory_(ceqmethod_factory),
     manager_(std::make_shared<ParameterManager>()),
     model_  (factory->CreateModel(manager_)),
     weiss_  (std::make_shared<WeissMethod> (manager_)),
@@ -138,7 +139,7 @@ unsigned CombinedModel::GetParameterIndex(const std::string &name) const
 
 std::shared_ptr<CombinedModel> CombinedModel::clone() const
 {
-    auto ret = std::make_shared<CombinedModel>(factory_);
+    auto ret = std::make_shared<CombinedModel>(factory_, ceqmethod_factory_);
     ret->SetApplyConstraints(AreConstraintsApplied());
     return ret;
 }

--- a/src/core/models/combinedmodel.cpp
+++ b/src/core/models/combinedmodel.cpp
@@ -25,7 +25,7 @@ CombinedModel::CombinedModel(ModelFactory* factory, CEqMethodFactory* ceqmethod_
      ceqmethod_factory_(ceqmethod_factory),
      manager_(std::make_shared<ParameterManager>()),
     model_  (factory->CreateModel(manager_)),
-     ceqmethod_ (ceqmethod_factory_->CreateCEqMethod(manager_)),
+     ceqmethod_ (ceqmethod_factory->CreateCEqMethod(manager_)),
      clever_ (std::make_shared<CleverMethod>(manager_)),
     model_accessor_ ( model_->GetParameterAccessor()),
      ceqmethod_accessor_ (ceqmethod_->GetParameterAccessor()),

--- a/src/core/models/combinedmodel.cpp
+++ b/src/core/models/combinedmodel.cpp
@@ -63,7 +63,7 @@ void CombinedModel::SetupDerivatives(const std::vector<int> &indices)
 
 double CombinedModel::CalculateEquilibriumConcentration(GasType gas)
 {
-    return (gas == Gas::XE && ceqmethod_factory_->GetCEqMethodName() == "WeissClever") ? //WIP: Schöner lösen?
+    return (gas == Gas::XE && ceqmethod_factory_->GetCEqMethodName() == "WeissClever") ?
                 clever_->CalculateConcentration(clever_accessor_, Gas::XE) :
                 ceqmethod_ ->CalculateConcentration( ceqmethod_accessor_, gas); 
 }
@@ -144,7 +144,7 @@ std::shared_ptr<CombinedModel> CombinedModel::clone() const
     return ret;
 }
 
-std::string CombinedModel::GetExcessAirModelName() const //WIP: Auch noch für Method einbauen, wo wird es verwendet?
+std::string CombinedModel::GetExcessAirModelName() const
 {
     return  model_->GetModelName();
 }

--- a/src/core/models/combinedmodel.h
+++ b/src/core/models/combinedmodel.h
@@ -123,6 +123,9 @@ public:
     //! Gibt den Namen des verwendeten ExcessAirModels zurück.
     std::string GetExcessAirModelName() const;
 
+    //! Gibt den Namen der verwendeten CEqMethod zurück.
+    std::string GetCEqMethodName() const;
+
     //! \brief Wenn auf wahr gesetzt wird vom Modell nan zurückgegeben falls
     //! Parameterwerte außerhalb der Constraints angegeben werden.
     void SetApplyConstraints(bool apply);

--- a/src/core/models/combinedmodel.h
+++ b/src/core/models/combinedmodel.h
@@ -30,8 +30,9 @@
 #include "core/misc/gas.h"
 
 #include "modelfactory.h"
+#include "ceqmethodfactory.h" //WIP: Welche includes noch notwendig?
 #include "clevermethod.h"
-#include "weissmethod.h"
+
 #include "parametermanager.h"
 #include "parameteraccessor.h"
 #include "derivativecollector.h"
@@ -49,11 +50,7 @@ class CombinedModel
 public:
 
     //! Erzeugt mit dem mit der übergebenen Factory erstellten ExcessAirModel ein CombinedModel.
-    /*!
-      Derzeit können die C_eq-Berechnungsmethoden noch nicht gewählt werden. Für Xe wird Clever
-      verwendet, für alle anderen Gase Weiss.
-      */
-    CombinedModel(ModelFactory* factory, ModelFactory* ceqmethod_factory);
+    CombinedModel(ModelFactory* factory, CEqMethodFactory* ceqmethod_factory);
 
     //! Setzt neue Parameter-Werte.
     /*!
@@ -142,7 +139,7 @@ private:
     factory_;
 
     //! ModelFactory wird gespeichert um das CombinedModel leicht klonen zu können.
-    ModelFactory*
+    CEqMethodFactory*
     ceqmethod_factory_;
 
     //! ParameterManager der zur Konfiguration der Modelle verwendet wird.
@@ -151,8 +148,8 @@ private:
     //! Verwendetes ExcessAirModel
     std::shared_ptr<ExcessAirModel> model_;
 
-    //! Weiss-Methode zur Berechnung der Gleichgewichtskonzentrationen von He, Ne, Ar, Kr.
-    std::shared_ptr<WeissMethod> weiss_;
+    //! Verwendete CEqCalculationMethod
+    std::shared_ptr<CEqCalculationMethod> ceqmethod_;
 
     //! Clever-Methode zur Berechnung der Gleichgewichtskonzentrationen von Xe.
     std::shared_ptr<CleverMethod> clever_;
@@ -160,8 +157,8 @@ private:
     //! ParameterAccessor des \ref ExcessAirModel "ExcessAirModels".
     std::shared_ptr<ParameterAccessor>  model_accessor_;
 
-    //! ParameterAccessor der WeissMethod.
-    std::shared_ptr<ParameterAccessor>  weiss_accessor_;
+    //! ParameterAccessor der \ref CEqCalculationMethod "CEqCalculationMethods". //WIP: Anpassen
+    std::shared_ptr<ParameterAccessor>  ceqmethod_accessor_;
 
     //! ParameterAccessor der CleverMethod.
     std::shared_ptr<ParameterAccessor> clever_accessor_;
@@ -169,8 +166,8 @@ private:
     //! DerivativeCollector des \ref ExcessAirModel "ExcessAirModels".
     std::shared_ptr<DerivativeCollector>  model_collector_;
 
-    //! DerivativeCollector der WeissMethod.
-    std::shared_ptr<DerivativeCollector>  weiss_collector_;
+    //! DerivativeCollector des \ref CEqCalculationMethod "CEqCalculationMethods". //WIP: Anpassen
+    std::shared_ptr<DerivativeCollector>  ceqmethod_collector_;
 
     //! DerivativeCollector der CleverMethod.
     std::shared_ptr<DerivativeCollector> clever_collector_;

--- a/src/core/models/combinedmodel.h
+++ b/src/core/models/combinedmodel.h
@@ -160,7 +160,7 @@ private:
     //! ParameterAccessor des \ref ExcessAirModel "ExcessAirModels".
     std::shared_ptr<ParameterAccessor>  model_accessor_;
 
-    //! ParameterAccessor der \ref CEqCalculationMethod "CEqCalculationMethods". //WIP: Anpassen
+    //! ParameterAccessor der \ref CEqCalculationMethod "CEqCalculationMethods".
     std::shared_ptr<ParameterAccessor>  ceqmethod_accessor_;
 
     //! ParameterAccessor der CleverMethod.
@@ -169,7 +169,7 @@ private:
     //! DerivativeCollector des \ref ExcessAirModel "ExcessAirModels".
     std::shared_ptr<DerivativeCollector>  model_collector_;
 
-    //! DerivativeCollector des \ref CEqCalculationMethod "CEqCalculationMethods". //WIP: Anpassen
+    //! DerivativeCollector des \ref CEqCalculationMethod "CEqCalculationMethods".
     std::shared_ptr<DerivativeCollector>  ceqmethod_collector_;
 
     //! DerivativeCollector der CleverMethod.

--- a/src/core/models/combinedmodel.h
+++ b/src/core/models/combinedmodel.h
@@ -30,7 +30,7 @@
 #include "core/misc/gas.h"
 
 #include "modelfactory.h"
-#include "ceqmethodfactory.h" //WIP: Welche includes noch notwendig?
+#include "ceqmethodfactory.h"
 #include "clevermethod.h"
 
 #include "parametermanager.h"

--- a/src/core/models/combinedmodel.h
+++ b/src/core/models/combinedmodel.h
@@ -53,7 +53,7 @@ public:
       Derzeit können die C_eq-Berechnungsmethoden noch nicht gewählt werden. Für Xe wird Clever
       verwendet, für alle anderen Gase Weiss.
       */
-    CombinedModel(ModelFactory* factory);
+    CombinedModel(ModelFactory* factory, ModelFactory* ceqmethod_factory);
 
     //! Setzt neue Parameter-Werte.
     /*!
@@ -140,6 +140,10 @@ private:
     //! ModelFactory wird gespeichert um das CombinedModel leicht klonen zu können.
     ModelFactory*
     factory_;
+
+    //! ModelFactory wird gespeichert um das CombinedModel leicht klonen zu können.
+    ModelFactory*
+    ceqmethod_factory_;
 
     //! ParameterManager der zur Konfiguration der Modelle verwendet wird.
     std::shared_ptr<ParameterManager> manager_;

--- a/src/core/models/combinedmodelfactory.cpp
+++ b/src/core/models/combinedmodelfactory.cpp
@@ -30,6 +30,8 @@ std::shared_ptr<CombinedModel> CombinedModelFactory::CreateModel() const
 {
     if (!factory_)
         throw std::runtime_error("CombinedModelFactory: No factory set.");
+    if (!ceqmethod_factory_)
+        throw std::runtime_error("CombinedModelFactory: No ceqmethod_factory set.");
     return std::make_shared<CombinedModel>(factory_, ceqmethod_factory_);
 }
 

--- a/src/core/models/combinedmodelfactory.cpp
+++ b/src/core/models/combinedmodelfactory.cpp
@@ -20,7 +20,7 @@
 
 #include "combinedmodelfactory.h"
 
-CombinedModelFactory::CombinedModelFactory(ModelFactory* factory, ModelFactory* ceqmethod_factory) :
+CombinedModelFactory::CombinedModelFactory(ModelFactory* factory, CEqMethodFactory* ceqmethod_factory) :
     factory_(factory),
     ceqmethod_factory_(ceqmethod_factory)
 {

--- a/src/core/models/combinedmodelfactory.cpp
+++ b/src/core/models/combinedmodelfactory.cpp
@@ -20,8 +20,9 @@
 
 #include "combinedmodelfactory.h"
 
-CombinedModelFactory::CombinedModelFactory(ModelFactory* factory) :
-    factory_(factory)
+CombinedModelFactory::CombinedModelFactory(ModelFactory* factory, ModelFactory* ceqmethod_factory) :
+    factory_(factory),
+    ceqmethod_factory_(ceqmethod_factory)
 {
 }
 
@@ -29,7 +30,7 @@ std::shared_ptr<CombinedModel> CombinedModelFactory::CreateModel() const
 {
     if (!factory_)
         throw std::runtime_error("CombinedModelFactory: No factory set.");
-    return std::make_shared<CombinedModel>(factory_);
+    return std::make_shared<CombinedModel>(factory_, ceqmethod_factory_);
 }
 
 std::string CombinedModelFactory::GetExcessAirModelName() const

--- a/src/core/models/combinedmodelfactory.h
+++ b/src/core/models/combinedmodelfactory.h
@@ -28,7 +28,7 @@
 class CombinedModelFactory
 {
 public:
-    CombinedModelFactory(ModelFactory* factory = nullptr);
+    CombinedModelFactory(ModelFactory* factory = nullptr, ModelFactory* ceqmethod_factory = nullptr);
     std::shared_ptr<CombinedModel> CreateModel() const;
     
     //! \todo Entfernen und durch die Methode in CombinedModel ersetzen.
@@ -36,6 +36,7 @@ public:
 
 private:
     ModelFactory* factory_;
+    ModelFactory* ceqmethod_factory_;
 };
 
 #endif // COMBINEDMODELFACTORY_H

--- a/src/core/models/combinedmodelfactory.h
+++ b/src/core/models/combinedmodelfactory.h
@@ -28,7 +28,7 @@
 class CombinedModelFactory
 {
 public:
-    CombinedModelFactory(ModelFactory* factory = nullptr, ModelFactory* ceqmethod_factory = nullptr);
+    CombinedModelFactory(ModelFactory* factory = nullptr, CEqMethodFactory* ceqmethod_factory = nullptr);
     std::shared_ptr<CombinedModel> CreateModel() const;
     
     //! \todo Entfernen und durch die Methode in CombinedModel ersetzen.
@@ -36,7 +36,7 @@ public:
 
 private:
     ModelFactory* factory_;
-    ModelFactory* ceqmethod_factory_;
+    CEqMethodFactory* ceqmethod_factory_;
 };
 
 #endif // COMBINEDMODELFACTORY_H

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -26,7 +26,7 @@
 
 const std::string JenkinsMethod::NAME = "Jenkins";
 
-std::string JenkinsMethod::GetCEqMethodName() const //WIP: Verwendet?
+std::string JenkinsMethod::GetCEqMethodName() const
 {
     return JenkinsMethod::NAME;
 }
@@ -57,8 +57,8 @@ void JenkinsMethod::CalculateDerivatives(
 {
     DEFINE_PARAMETER_ACCESSOR(x, parameters);
 
-    // Temperatur in Kelvin
-    const double t_k = x->T() + 273.15;
+    // Temperatur in Kelvin divided by 100
+    const double t_k = ( x->T() + 273.15 )/100;
 
     // Sättigungsdampfdruck.
     const double p_w = PhysicalProperties::CalcSaturationVaporPressure(x->T());
@@ -101,7 +101,7 @@ void JenkinsMethod::CalculateDerivatives(
                             x->S() *
                             (s2[gas_for_calculations] +
                              s3[gas_for_calculations] * 2 * t_k))
-
+                            * 1/100 //dt_k/dT
                            +
 
                            (x->p() - 1.) / std::pow(1. - p_w, 2.) * //Ableitung von "frac"
@@ -115,7 +115,7 @@ void JenkinsMethod::CalculateDerivatives(
         }
     }
     
-    if (gas == Gas::HE3) //WIP: durchgehen
+    if (gas == Gas::HE3)
     {
         DERIVATIVE_LOOP(parameter, derivative, derivatives)
         {
@@ -145,7 +145,7 @@ void JenkinsMethod::CalculateDerivatives(
 double JenkinsMethod::CalcJenkinsExpFunction(double t, double s, GasType gas)
 {
     // Temperatur in Kelvin
-    const double t_k = t + 273.15;
+    const double t_k = ( t + 273.15 )/100; //Faktor 100 hier statt in exp
 
     return std::exp(t1[gas] +
                     t2[gas] / t_k +
@@ -168,7 +168,7 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
     double concentration =
             CalcJenkinsExpFunction(T,
                                  S,
-                                 gas != Gas::HE3 ? gas : Gas::HE) * //WIP: check HE3
+                                 gas != Gas::HE3 ? gas : Gas::HE) * 
             PhysicalProperties::GetMolarVolume(gas) / 1000. * //Umrechnung von mol/kg nach ccSTP/g
             p_dry / (1 - p_w);
 
@@ -180,51 +180,51 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
 
 
 //Die Reihenfolge der Gase muss dem enum in "gas.h" entsprechen.
-//Das Teilen durch 100 wurde in die Konstanten t1, t2, t4, s2, s3 eingerechnet. (WIP: change)
-const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of( -826.322866779936) //Helium
-                                                                    (-1319.35732470527 ) //Neon
-                                                                    (-1058.82194230202 ) //Argon
-                                                                    ( -445.738071028788) //Krypton
-                                                                    ( -950.343306973085);//Xenon
+//Konstanten von Jenkins et al. 2019 für Konzentrationen in mol/kg (Umrechnung folgt in CalculateConcentration)
+const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of( -178.1424      ) //Helium
+                                                                    ( -274.1329      ) //Neon
+                                                                    ( -227.4607      ) //Argon
+                                                                    ( -122.4694      ) //Krypton
+                                                                    ( -224.5100      );//Xenon
 
-const std::vector<double> JenkinsMethod::t2 = boost::assign::list_of(21759.91          ) //Helium
-                                                                    (35262.01          ) //Neon
-                                                                    (30543.47          ) //Argon
-                                                                    (15356.54          ) //Krypton
-                                                                    (29282.34          );//Xenon
+const std::vector<double> JenkinsMethod::t2 = boost::assign::list_of(  217.5991      ) //Helium
+                                                                    (  352.6201      ) //Neon
+                                                                    (  305.4347      ) //Argon
+                                                                    (  153.5654      ) //Krypton
+                                                                    (  292.8234      );//Xenon
  
-const std::vector<double> JenkinsMethod::t3 = boost::assign::list_of(  140.7506        ) //Helium
-                                                                    (  226.9676        ) //Neon
-                                                                    (  180.5278        ) //Argon
-                                                                    (   70.1969        ) //Krypton
-                                                                    (  157.6127        );//Xenon
+const std::vector<double> JenkinsMethod::t3 = boost::assign::list_of(  140.7506      ) //Helium
+                                                                    (  226.9676      ) //Neon
+                                                                    (  180.5278      ) //Argon
+                                                                    (   70.1969      ) //Krypton
+                                                                    (  157.6127      );//Xenon
  
-const std::vector<double> JenkinsMethod::t4 = boost::assign::list_of(   -0.2301954     ) //Helium
-                                                                    (   -0.3713393     ) //Neon
-                                                                    (   -0.279945      ) //Argon
-                                                                    (   -0.0852524     ) //Krypton
-                                                                    (   -0.2266895     );//Xenon
+const std::vector<double> JenkinsMethod::t4 = boost::assign::list_of(  -23.01954     ) //Helium
+                                                                    (  -37.13393     ) //Neon
+                                                                    (  -27.9945      ) //Argon
+                                                                    (  - 8.52524     ) //Krypton
+                                                                    (  -22.66895     );//Xenon
  
-const std::vector<double> JenkinsMethod::s1 = boost::assign::list_of(   -0.038129      ) //Helium
-                                                                    (   -0.06386       ) //Neon
-                                                                    (   -0.066942      ) //Argon
-                                                                    (   -0.049522      ) //Krypton
-                                                                    (   -0.084915      );//Xenon
+const std::vector<double> JenkinsMethod::s1 = boost::assign::list_of(   -0.038129    ) //Helium
+                                                                    (   -0.06386     ) //Neon
+                                                                    (   -0.066942    ) //Argon
+                                                                    (   -0.049522    ) //Krypton
+                                                                    (   -0.084915    );//Xenon
  
-const std::vector<double> JenkinsMethod::s2 = boost::assign::list_of(    0.0001919     ) //Helium
-                                                                    (    0.00035326    ) //Neon
-                                                                    (    0.00037201    ) //Argon
-                                                                    (    0.00024434    ) //Krypton
-                                                                    (    0.00047996    );//Xenon
+const std::vector<double> JenkinsMethod::s2 = boost::assign::list_of(    0.019190    ) //Helium
+                                                                    (    0.035326    ) //Neon
+                                                                    (    0.037201    ) //Argon
+                                                                    (    0.024434    ) //Krypton
+                                                                    (    0.047996    );//Xenon
  
-const std::vector<double> JenkinsMethod::s3 = boost::assign::list_of(   -2.6898E-07    ) //Helium
-                                                                    (   -5.3258E-07    ) //Neon
-                                                                    (   -5.6364E-07    ) //Argon
-                                                                    (   -3.3968E-07    ) //Krypton
-                                                                    (   -7.3595E-07    );//Xenon
+const std::vector<double> JenkinsMethod::s3 = boost::assign::list_of(   -2.6898E-03  ) //Helium
+                                                                    (   -5.3258E-03  ) //Neon
+                                                                    (   -5.6364E-03  ) //Argon
+                                                                    (   -3.3968E-03  ) //Krypton
+                                                                    (   -7.3595E-03  );//Xenon
  
-const std::vector<double> JenkinsMethod::s4 = boost::assign::list_of(   -0.00000255    ) //Helium //WIP: Achtung, muss in JenkinsMethod auch drin sein
-                                                                    (    0.0000128     ) //Neon
-                                                                    (   -0.0000053     ) //Argon
-                                                                    (    0.00000419    ) //Krypton
-                                                                    (    0.00000669    );//Xenon
+const std::vector<double> JenkinsMethod::s4 = boost::assign::list_of(   -2.55157E-06 ) //Helium 
+                                                                    (    1.28233E-05 ) //Neon
+                                                                    (   -5.30325E-06 ) //Argon
+                                                                    (    4.19208E-06 ) //Krypton
+                                                                    (    6.69292E-06 );//Xenon

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -69,7 +69,7 @@ void JenkinsMethod::CalculateDerivatives(
     GasType gas_for_calculations = gas != Gas::HE3 ? gas : Gas::HE;
     
     const double exponential =
-            CalcJenkinsExpFunction(x->T(), x->S(), gas_for_calculations) * PhysicalProperties::GetMolarVolume(gas) / 1000.;
+            CalcJenkinsExpFunction(x->T(), x->S(), gas_for_calculations) * PhysicalProperties::GetMolarVolume(gas_for_calculations) / 1000.;
 
     DERIVATIVE_LOOP(parameter, derivative, derivatives)
     {
@@ -176,7 +176,7 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
             CalcJenkinsExpFunction(T,
                                  S,
                                  gas != Gas::HE3 ? gas : Gas::HE) * 
-            PhysicalProperties::GetMolarVolume(gas) / 1000. * //Umrechnung von mol/kg nach ccSTP/g
+            PhysicalProperties::GetMolarVolume(gas != Gas::HE3 ? gas : Gas::HE) / 1000. * //Umrechnung von mol/kg nach ccSTP/g
             p_dry / (1 - p_w);
 
     if (gas == Gas::HE3)

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -69,7 +69,7 @@ void JenkinsMethod::CalculateDerivatives(
     GasType gas_for_calculations = gas != Gas::HE3 ? gas : Gas::HE;
     
     const double exponential =
-            CalcJenkinsExpFunction(x->T(), x->S(), gas_for_calculations) / 1000.;
+            CalcJenkinsExpFunction(x->T(), x->S(), gas_for_calculations) * PhysicalProperties::GetMolarVolume(gas) / 1000.;
 
     DERIVATIVE_LOOP(parameter, derivative, derivatives)
     {
@@ -168,8 +168,9 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
     double concentration =
             CalcJenkinsExpFunction(T,
                                  S,
-                                 gas != Gas::HE3 ? gas : Gas::HE) *
-            p_dry / (1 - p_w) / 1000;
+                                 gas != Gas::HE3 ? gas : Gas::HE) * //WIP: check HE3
+            PhysicalProperties::GetMolarVolume(gas) / 1000. * //Umrechnung von mol/kg nach ccSTP/g
+            p_dry / (1 - p_w);
 
     if (gas == Gas::HE3)
         return concentration * PhysicalProperties::CalcReq(T, S);
@@ -177,18 +178,14 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
     return concentration;
 }
 
-//WIP: Molekulares Volumen der Gase eigentlich hier definieren um die Koeffizienten direkt hier zu berechnen?
 
 //Die Reihenfolge der Gase muss dem enum in "gas.h" entsprechen.
-//Die Konstanten wurden auf zwei Weisen umgerechnet:
-//das Teilen durch 100 wurde eingerechnet
-//und die Umrechnung von mol/kg nach ccSTP/kg ist in t1 integriert (molare Volumen aus Porcelli, Noble Gases in Geochemistry and Cosmochemistry).
-//(In CalculateConcentration wird durch das Teilen durch 1000 dann mit ccSTP/g gerechnet.)
-const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of( -816.304426860976) //Helium
-                                                                    (-1309.33954018636 ) //Neon
-                                                                    (-1048.80572892443 ) //Argon
-                                                                    ( -435.723435738912) //Krypton
-                                                                    ( -940.331844325884);//Xenon
+//Das Teilen durch 100 wurde in die Konstanten t1, t2, t4, s2, s3 eingerechnet. (WIP: change)
+const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of( -826.322866779936) //Helium
+                                                                    (-1319.35732470527 ) //Neon
+                                                                    (-1058.82194230202 ) //Argon
+                                                                    ( -445.738071028788) //Krypton
+                                                                    ( -950.343306973085);//Xenon
 
 const std::vector<double> JenkinsMethod::t2 = boost::assign::list_of(21759.91          ) //Helium
                                                                     (35262.01          ) //Neon

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -177,9 +177,13 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
     return concentration;
 }
 
-//WIP: Molekulares Volumen der Gase eigentlich hier definieren?
+//WIP: Molekulares Volumen der Gase eigentlich hier definieren um die Koeffizienten direkt hier zu berechnen?
+
 //Die Reihenfolge der Gase muss dem enum in "gas.h" entsprechen.
-//Die Konstanten wurden umgerechnet, um das Teilen durch 100 zu vermeiden.
+//Die Konstanten wurden auf zwei Weisen umgerechnet:
+//das Teilen durch 100 wurde eingerechnet
+//und die Umrechnung von mol/kg nach ccSTP/kg ist in t1 integriert (molare Volumen aus Porcelli, Noble Gases in Geochemistry and Cosmochemistry).
+//(In CalculateConcentration wird durch das Teilen durch 1000 dann mit ccSTP/g gerechnet.)
 const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of( -816.304426860976) //Helium
                                                                     (-1309.33954018636 ) //Neon
                                                                     (-1048.80572892443 ) //Argon

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -24,7 +24,7 @@
 
 #include "jenkinsmethod.h"
 
-const std::string JenkinsMethod::NAME = "JenkinsClever"; 
+const std::string JenkinsMethod::NAME = "JenkinsClever";
 
 std::string JenkinsMethod::GetCEqMethodName() const //WIP: Verwendet?
 {
@@ -55,10 +55,6 @@ void JenkinsMethod::CalculateDerivatives(
     GasType gas
     ) const
 {
-    if (gas == Gas::XE)
-        throw std::runtime_error("Xe equilibrium concentrations cannot be calculated using the"
-                                 " Jenkins method.");
-
     DEFINE_PARAMETER_ACCESSOR(x, parameters);
 
     // Temperatur in Kelvin
@@ -89,7 +85,8 @@ void JenkinsMethod::CalculateDerivatives(
             derivative = exponential * frac *
                           (s1[gas_for_calculations] +
                            s2[gas_for_calculations] * t_k +
-                           s3[gas_for_calculations] * t_k * t_k);
+                           s3[gas_for_calculations] * t_k * t_k +
+                           s4[gas_for_calculations] * 2* x->S() );
             break;
 
         case Jenkins::T:
@@ -118,7 +115,7 @@ void JenkinsMethod::CalculateDerivatives(
         }
     }
     
-    if (gas == Gas::HE3)
+    if (gas == Gas::HE3) //WIP: durchgehen
     {
         DERIVATIVE_LOOP(parameter, derivative, derivatives)
         {
@@ -156,15 +153,12 @@ double JenkinsMethod::CalcJenkinsExpFunction(double t, double s, GasType gas)
                     t4[gas] * t_k +
                     s * (s1[gas] +
                          s2[gas] * t_k +
-                         s3[gas] * t_k * t_k));
+                         s3[gas] * t_k * t_k)+
+                    s * s * s4[gas]);
 }
 
 double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasType gas)
 {
-    if (gas == Gas::XE)
-        throw std::runtime_error("Xe equilibrium concentrations cannot be calculated using the"
-                                 " Jenkins method.");
-
     // Sättigungsdampfdruck in atm.
     const double p_w = PhysicalProperties::CalcSaturationVaporPressure(T);
 
@@ -183,40 +177,53 @@ double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasTy
     return concentration;
 }
 
-// WIP: Sind noch Weiss-Daten!
+//WIP: Molekulares Volumen der Gase eigentlich hier definieren?
 //Die Reihenfolge der Gase muss dem enum in "gas.h" entsprechen.
 //Die Konstanten wurden umgerechnet, um das Teilen durch 100 zu vermeiden.
-const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of(  -808.2722264341 ) //Helium
-                                                                  (  -819.4071883742 ) //Neon
-                                                                  (  -846.9984052407 ) //Argon
-                                                                  (  -455.6264185803 );//Krypton
+const std::vector<double> JenkinsMethod::t1 = boost::assign::list_of( -816.304426860976) //Helium
+                                                                    (-1309.33954018636 ) //Neon
+                                                                    (-1048.80572892443 ) //Argon
+                                                                    ( -435.723435738912) //Krypton
+                                                                    ( -940.331844325884);//Xenon
 
-const std::vector<double> JenkinsMethod::t2 = boost::assign::list_of( 21634.42         ) //Helium
-                                                                  ( 22519.46         ) //Neon
-                                                                  ( 25181.39         ) //Argon
-                                                                  ( 15358.17         );//Krypton
-
-const std::vector<double> JenkinsMethod::t3 = boost::assign::list_of(   139.2032       ) //Helium
-                                                                  (   140.8863       ) //Neon
-                                                                  (   145.2337       ) //Argon
-                                                                  (    74.469        );//Krypton
-
-const std::vector<double> JenkinsMethod::t4 = boost::assign::list_of(    -0.226202     ) //Helium
-                                                                  (    -0.22629      ) //Neon
-                                                                  (    -0.222046     ) //Argon
-                                                                  (    -0.100189     );//Krypton
-
-const std::vector<double> JenkinsMethod::s1 = boost::assign::list_of(    -0.044781     ) //Helium
-                                                                  (    -0.127113     ) //Neon
-                                                                  (    -0.038729     ) //Argon
-                                                                  (    -0.011213     );//Krypton
-
-const std::vector<double> JenkinsMethod::s2 = boost::assign::list_of(     0.00023541   ) //Helium
-                                                                  (     0.00079277   ) //Neon
-                                                                  (     0.00017171   ) //Argon
-                                                                  (    -1.844e-05    );//Krypton
-
-const std::vector<double> JenkinsMethod::s3 = boost::assign::list_of(    -3.4266e-07   ) //Helium
-                                                                  (    -1.29095e-06  ) //Neon
-                                                                  (    -2.1281e-07   ) //Argon
-                                                                  (     1.1201e-07   );//Krypton
+const std::vector<double> JenkinsMethod::t2 = boost::assign::list_of(21759.91          ) //Helium
+                                                                    (35262.01          ) //Neon
+                                                                    (30543.47          ) //Argon
+                                                                    (15356.54          ) //Krypton
+                                                                    (29282.34          );//Xenon
+ 
+const std::vector<double> JenkinsMethod::t3 = boost::assign::list_of(  140.7506        ) //Helium
+                                                                    (  226.9676        ) //Neon
+                                                                    (  180.5278        ) //Argon
+                                                                    (   70.1969        ) //Krypton
+                                                                    (  157.6127        );//Xenon
+ 
+const std::vector<double> JenkinsMethod::t4 = boost::assign::list_of(   -0.2301954     ) //Helium
+                                                                    (   -0.3713393     ) //Neon
+                                                                    (   -0.279945      ) //Argon
+                                                                    (   -0.0852524     ) //Krypton
+                                                                    (   -0.2266895     );//Xenon
+ 
+const std::vector<double> JenkinsMethod::s1 = boost::assign::list_of(   -0.038129      ) //Helium
+                                                                    (   -0.06386       ) //Neon
+                                                                    (   -0.066942      ) //Argon
+                                                                    (   -0.049522      ) //Krypton
+                                                                    (   -0.084915      );//Xenon
+ 
+const std::vector<double> JenkinsMethod::s2 = boost::assign::list_of(    0.0001919     ) //Helium
+                                                                    (    0.00035326    ) //Neon
+                                                                    (    0.00037201    ) //Argon
+                                                                    (    0.00024434    ) //Krypton
+                                                                    (    0.00047996    );//Xenon
+ 
+const std::vector<double> JenkinsMethod::s3 = boost::assign::list_of(   -2.6898E-07    ) //Helium
+                                                                    (   -5.3258E-07    ) //Neon
+                                                                    (   -5.6364E-07    ) //Argon
+                                                                    (   -3.3968E-07    ) //Krypton
+                                                                    (   -7.3595E-07    );//Xenon
+ 
+const std::vector<double> JenkinsMethod::s4 = boost::assign::list_of(   -0.00000255    ) //Helium //WIP: Achtung, muss in JenkinsMethod auch drin sein
+                                                                    (    0.0000128     ) //Neon
+                                                                    (   -0.0000053     ) //Argon
+                                                                    (    0.00000419    ) //Krypton
+                                                                    (    0.00000669    );//Xenon

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -61,7 +61,7 @@ void JenkinsMethod::CalculateDerivatives(
     const double t_k = ( x->T() + 273.15 )/100;
 
     // Sättigungsdampfdruck.
-    const double p_w = PhysicalProperties::CalcSaturationVaporPressure(x->T());
+    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Gill(x->T());
 
     // (p - pw) / (1 - pw)
     const double frac = (x->p() - p_w) / (1. - p_w);
@@ -105,7 +105,7 @@ void JenkinsMethod::CalculateDerivatives(
                            +
 
                            (x->p() - 1.) / std::pow(1. - p_w, 2.) * //Ableitung von "frac"
-                           PhysicalProperties::CalcSaturationVaporPressureDerivative(x->T()));
+                           PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(x->T()));
             break;
 
         case Jenkins::OTHER:
@@ -160,7 +160,7 @@ double JenkinsMethod::CalcJenkinsExpFunction(double t, double s, GasType gas)
 double JenkinsMethod::CalculateConcentration(double p, double S, double T, GasType gas)
 {
     // Sättigungsdampfdruck in atm.
-    const double p_w = PhysicalProperties::CalcSaturationVaporPressure(T);
+    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Gill(T);
 
     // Partialdruck der trockenen Luft.
     const double p_dry = p - p_w;

--- a/src/core/models/jenkinsmethod.cpp
+++ b/src/core/models/jenkinsmethod.cpp
@@ -24,7 +24,7 @@
 
 #include "jenkinsmethod.h"
 
-const std::string JenkinsMethod::NAME = "JenkinsClever";
+const std::string JenkinsMethod::NAME = "Jenkins";
 
 std::string JenkinsMethod::GetCEqMethodName() const //WIP: Verwendet?
 {

--- a/src/core/models/jenkinsmethod.h
+++ b/src/core/models/jenkinsmethod.h
@@ -30,7 +30,7 @@
 #define NOBLE_IS_CEQ_CALCULATION_METHOD
 #include "generatehelperclasses.h"
 
-//! Berechnung von Gleichgewichtskonzentrationen nach Weiss. //WIP: Jenkins eintragen
+//! Berechnung von Gleichgewichtskonzentrationen nach Jenkins. //WIP: Jenkins hier eintragen:
 /*!
   Aus Kipfer et al. 2002, Noble Gases in Lakes and Ground Waters:
   \f[
@@ -116,6 +116,9 @@ private:
 
     //! Jenkins coefficient.
     static const std::vector<double> s3;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> s4;
 };
 
 #endif // JENKINSMETHOD_H

--- a/src/core/models/jenkinsmethod.h
+++ b/src/core/models/jenkinsmethod.h
@@ -1,0 +1,121 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef JENKINSMETHOD_H
+#define JENKINSMETHOD_H
+
+#include <memory>
+
+#include "ceqcalculationmethod.h"
+#include "parametermanager.h"
+
+#define NOBLE_PARAMETER_COUNT 3
+#define NOBLE_PARAMETER_NAMES (p, S, T)
+#define NOBLE_CLASS_PREFIX Jenkins
+#define NOBLE_IS_CEQ_CALCULATION_METHOD
+#include "generatehelperclasses.h"
+
+//! Berechnung von Gleichgewichtskonzentrationen nach Weiss. //WIP: Jenkins eintragen
+/*!
+  Aus Kipfer et al. 2002, Noble Gases in Lakes and Ground Waters:
+  \f[
+    C^i_{eq}=exp\left(t^i_1+
+                      t^i_2\cdot\frac{100}{T}+
+                      t^i_3\cdot ln\left(\frac{T}{100}\right)+
+                      t^i_4\cdot\frac{T}{100}+
+                      S\cdot\left[s^i_1+
+                                  s^i_2\cdot\frac{T}{100}+
+                                  s^i_3\cdot\left(\frac{T}{100}\right)^2
+                                  \right]
+                      \right)\cdot
+             \frac{p-e_w(T)}{(1-e_w(T))\cdot1000}
+  \f]
+
+  \f$C^i_{eq}\f$: Gleichgewichtskonzentration von i (He, Ne, Ar, Kr) in ccSTP/g.\n
+  \f$e_w\f$: Sättigungsdampfdruck des Wassers.\n
+  \f$p\f$: Luftdruck in atm.\n
+  \f$T\f$: Temperatur in K.\n
+  \f$S\f$: Salinität in g/kg.\n
+  \f$t^i_j\f$: Temperaturkoeffizienten.\n
+  \f$s^i_j\f$: Salinitätskoeffizienten.\n
+  */
+class JenkinsMethod : public CEqCalculationMethod
+{
+    #include "generatehelpermethods.h"
+public:
+
+    JenkinsMethod(std::shared_ptr<ParameterManager> manager);
+
+    ~JenkinsMethod() {}
+
+    double CalculateConcentration(
+        std::shared_ptr<ParameterAccessor> parameters,
+        GasType gas
+        ) const;
+
+    void CalculateDerivatives(
+        std::shared_ptr<ParameterAccessor> parameters,
+        std::shared_ptr<DerivativeCollector> derivatives,
+        GasType gas
+        ) const;
+
+    //! Führt die eigentlich Berechnung der Konzentration durch.
+    /*!
+      \param p Druck in atm.
+      \param S Salinität in g/kg.
+      \param T Temperatur in °C.
+      \param gas Edelgas für das die Berechnung durchgeführt werden soll.
+      \return Gleichgewichtskonzentration in ccSTP/g.
+      */
+    static double CalculateConcentration(double p,
+                                         double S,
+                                         double T,
+                                         GasType gas);
+
+    static const std::string NAME;
+    
+    std::string GetCEqMethodName() const; //WIP: Verwendet?
+
+private:
+
+    //! Berechnet die exp-Funktion aus der Jenkins-Formel.
+    static double CalcJenkinsExpFunction(double t, double s, GasType gas);
+
+    //! Jenkins coefficient.
+    static const std::vector<double> t1;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> t2;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> t3;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> t4;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> s1;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> s2;
+
+    //! Jenkins coefficient.
+    static const std::vector<double> s3;
+};
+
+#endif // JENKINSMETHOD_H

--- a/src/core/models/jenkinsmethod.h
+++ b/src/core/models/jenkinsmethod.h
@@ -30,9 +30,11 @@
 #define NOBLE_IS_CEQ_CALCULATION_METHOD
 #include "generatehelperclasses.h"
 
-//! Berechnung von Gleichgewichtskonzentrationen nach Jenkins. //WIP: Jenkins hier eintragen:
+//! Berechnung von Gleichgewichtskonzentrationen nach Jenkins.
 /*!
-  Aus Kipfer et al. 2002, Noble Gases in Lakes and Ground Waters:
+  Aus Jenkins et al., A determination of atmospheric helium, neon, argon, krypton, 
+  and xenon solubility concentrations in water and seawater. 
+  Marine Chemistry, 211:94–107, Apr. 2019. 
   \f[
     C^i_{eq}=exp\left(t^i_1+
                       t^i_2\cdot\frac{100}{T}+
@@ -41,12 +43,13 @@
                       S\cdot\left[s^i_1+
                                   s^i_2\cdot\frac{T}{100}+
                                   s^i_3\cdot\left(\frac{T}{100}\right)^2
-                                  \right]
+                                  \right]+
+                      S^2s^i_4
                       \right)\cdot
              \frac{p-e_w(T)}{(1-e_w(T))\cdot1000}
   \f]
 
-  \f$C^i_{eq}\f$: Gleichgewichtskonzentration von i (He, Ne, Ar, Kr) in ccSTP/g.\n
+  \f$C^i_{eq}\f$: Gleichgewichtskonzentration von i (He, Ne, Ar, Kr) in mol/kg.\n
   \f$e_w\f$: Sättigungsdampfdruck des Wassers.\n
   \f$p\f$: Luftdruck in atm.\n
   \f$T\f$: Temperatur in K.\n
@@ -89,7 +92,7 @@ public:
 
     static const std::string NAME;
     
-    std::string GetCEqMethodName() const; //WIP: Verwendet?
+    std::string GetCEqMethodName() const;
 
 private:
 

--- a/src/core/models/jenkinsmethodfactory.cpp
+++ b/src/core/models/jenkinsmethodfactory.cpp
@@ -1,0 +1,37 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "jenkinsmethod.h"
+
+#include "jenkinsmethodfactory.h"
+
+JenkinsMethodFactory::~JenkinsMethodFactory()
+{
+}
+
+std::shared_ptr<CEqCalculationMethod> JenkinsMethodFactory::CreateCEqMethod(
+    std::shared_ptr<ParameterManager> manager
+) const
+{
+    return std::make_shared<JenkinsMethod>(manager);
+}
+
+std::string JenkinsMethodFactory::GetCEqMethodName() const
+{
+    return JenkinsMethod::NAME;
+}

--- a/src/core/models/jenkinsmethodfactory.h
+++ b/src/core/models/jenkinsmethodfactory.h
@@ -25,8 +25,8 @@ class JenkinsMethodFactory : public CEqMethodFactory
 {
 public:
     ~JenkinsMethodFactory();
-    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod( //WIP: Warum nicht direkt JenkinsMethod statt CEqCalculationMethod?
-        std::shared_ptr<ParameterManager> manager) const; //WIP: Problem: ParameterManager scheint hier noch zu fehlen als include
+    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod( 
+        std::shared_ptr<ParameterManager> manager) const; 
     std::string GetCEqMethodName() const;
 };
 

--- a/src/core/models/jenkinsmethodfactory.h
+++ b/src/core/models/jenkinsmethodfactory.h
@@ -1,0 +1,33 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef JENKINSMETHODFACTORY_H
+#define JENKINSMETHODFACTORY_H
+
+#include "ceqmethodfactory.h"
+
+class JenkinsMethodFactory : public CEqMethodFactory
+{
+public:
+    ~JenkinsMethodFactory();
+    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod( //WIP: Warum nicht direkt JenkinsMethod statt CEqCalculationMethod?
+        std::shared_ptr<ParameterManager> manager) const; //WIP: Problem: ParameterManager scheint hier noch zu fehlen als include
+    std::string GetCEqMethodName() const;
+};
+
+#endif // JENKINSMETHODFACTORY_H

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -32,10 +32,32 @@ const std::map<GasType, std::vector<double> > PhysicalProperties::virial_coeffic
     {Gas::XE, std::vector<double>({-130.00, -262.00, -87.0      })},
 };
 
+const double PhysicalProperties::molar_volume_ideal_gas_ = 22414.1;
+
+// Molare Volumen basierend auf CRC Handbook of Chemistry and Physics 76th Edition 1995-1996
+// werden nicht weiter verwendet
 const std::map<GasType, double> PhysicalProperties::molar_volumes_ =
     PhysicalProperties::CalculateMolarVolumes(PhysicalProperties::virial_coefficient_parameters_);
+std::map<GasType, double> PhysicalProperties::CalculateMolarVolumes(
+    const std::map<GasType, std::vector<double> > &a
+    )
+{
+    std::map<GasType, double> ret;
 
-const double PhysicalProperties::molar_volume_ideal_gas_ = 22414.1;
+    for (std::map<GasType, std::vector<double> >::const_iterator it = a.begin(); it != a.end(); ++it)
+    {
+        double b = 0;
+        unsigned i = 0;
+        for (std::vector<double>::const_iterator jt = it->second.begin();
+             jt != it->second.end();
+             ++jt, ++i)
+            b += *jt * std::pow(298.15 / 273.15 - 1, i);
+
+        ret[it->first] = b + molar_volume_ideal_gas_;
+    }
+
+    return ret;
+}
 
 // Molare Volumen basierend auf Dymond and Smith, 1980
 // calculated using the second Virial coefficient approximation
@@ -109,6 +131,7 @@ double PhysicalProperties::CalcSaturationVaporPressure_Dickson(double T_c, doubl
     //Convert to atm
     double vapor_press_atm = vapor_press_kPa/101.32501;
 
+    // Comparison:
     // double oldpressure = CalcSaturationVaporPressure(T_c);
     // printf("%.20g\n", vapor_press_atm);
     // printf("%.20g\n", oldpressure);
@@ -201,36 +224,17 @@ double PhysicalProperties::CalcXeSaltingCoefficient(double T_c)
     return -0.4431009868e2 + 0.218772e4 / T_k + 0.65527e1 * std::log(T_k);
 }
 
-double PhysicalProperties::ConvertToMole(double ccstp, GasType gas) //WIP: Verwendung molares Volumen
+double PhysicalProperties::ConvertToMole(double ccstp, GasType gas) //Wird nicht weiter verwendet
 {
     return ccstp / molar_volumes_.find(gas)->second;
 }
 
 double PhysicalProperties::ConvertToMolePerLiter(double ccstp_g, double p, double S, double T_c, GasType gas)
 {
-    return ccstp_g * CalcWaterDensity(p, S, T_c) / molar_volumes_.find(gas)->second; //WIP: Verwendung molares Volumen
+    return ccstp_g * CalcWaterDensity(p, S, T_c) / molar_volumes_.find(gas)->second; //Wird nicht weiter verwendet
 }
 
-std::map<GasType, double> PhysicalProperties::CalculateMolarVolumes(
-    const std::map<GasType, std::vector<double> > &a //WIP: virial_coefficient_parameters_
-    )
-{
-    std::map<GasType, double> ret;
 
-    for (std::map<GasType, std::vector<double> >::const_iterator it = a.begin(); it != a.end(); ++it)
-    {
-        double b = 0;
-        unsigned i = 0;
-        for (std::vector<double>::const_iterator jt = it->second.begin();
-             jt != it->second.end();
-             ++jt, ++i)
-            b += *jt * std::pow(298.15 / 273.15 - 1, i);
-
-        ret[it->first] = b + molar_volume_ideal_gas_;
-    }
-
-    return ret;
-}
 
 double PhysicalProperties::GetDryAirVolumeFraction(GasType gas)
 {

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -84,15 +84,15 @@ const double PhysicalProperties::r3_ = -1833.92;
 const double PhysicalProperties::r4_ = 0.000464;
 const double PhysicalProperties::r5_ = 1.384;
 
-double PhysicalProperties::CalcSaturationVaporPressure(double T_c)
+double PhysicalProperties::CalcSaturationVaporPressure_Gill(double T_c)
 {
     return std::exp( (c1_ + c2_ * T_c) / (1 + c3_ * T_c) )
             / 1013.25;
 }
 
-double PhysicalProperties::CalcSaturationVaporPressureDerivative(double T_c)
+double PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(double T_c)
 {
-    return CalcSaturationVaporPressure(T_c) *
+    return CalcSaturationVaporPressure_Gill(T_c) *
             (c2_ - c1_ * c3_) / std::pow(1 + c3_ * T_c, 2.);
 }
 

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -287,7 +287,7 @@ double PhysicalProperties::CalcReqDerivedByT(double t, double s)
 {
     const double t_k = t + 273.15;
     const double r_eq = CalcReq(t, s);
-    return -r_eq * (1 + r4_ * s) * (2 * r3_ / (t_k*t_k*t_k) - r2_ / (t_k*t_k));
+    return r_eq * (1 + r4_ * s) * (2 * r3_ / (t_k*t_k*t_k) + r2_ / (t_k*t_k));
 }
 
 double PhysicalProperties::CalcReqDerivedByS(double t, double s)

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -133,18 +133,18 @@ double PhysicalProperties::CalcXeSaltingCoefficient(double T_c)
     return -0.4431009868e2 + 0.218772e4 / T_k + 0.65527e1 * std::log(T_k);
 }
 
-double PhysicalProperties::ConvertToMole(double ccstp, GasType gas)
+double PhysicalProperties::ConvertToMole(double ccstp, GasType gas) //WIP: Verwendung molares Volumen
 {
     return ccstp / molar_volumes_.find(gas)->second;
 }
 
 double PhysicalProperties::ConvertToMolePerLiter(double ccstp_g, double p, double S, double T_c, GasType gas)
 {
-    return ccstp_g * CalcWaterDensity(p, S, T_c) / molar_volumes_.find(gas)->second;
+    return ccstp_g * CalcWaterDensity(p, S, T_c) / molar_volumes_.find(gas)->second; //WIP: Verwendung molares Volumen
 }
 
 std::map<GasType, double> PhysicalProperties::CalculateMolarVolumes(
-    const std::map<GasType, std::vector<double> > &a
+    const std::map<GasType, std::vector<double> > &a //WIP: virial_coefficient_parameters_
     )
 {
     std::map<GasType, double> ret;

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -35,20 +35,24 @@ const std::map<GasType, std::vector<double> > PhysicalProperties::virial_coeffic
 const std::map<GasType, double> PhysicalProperties::molar_volumes_ =
     PhysicalProperties::CalculateMolarVolumes(PhysicalProperties::virial_coefficient_parameters_);
 
-// (molare Volumen aus Porcelli, Noble Gases in Geochemistry and Cosmochemistry)
+const double PhysicalProperties::molar_volume_ideal_gas_ = 22414.1;
+
+// Molare Volumen basierend auf Dymond and Smith, 1980
+// calculated using the second Virial coefficient approximation
+// verwendet für die Umrechnung der Gleichgewichtskonzentrationen
 const std::map<GasType, double> PhysicalProperties::molar_volumes_new = { 
-    {Gas::HE, 22436.4}, // PangaMA: 22436.4, Matlab: 22425.9
-    {Gas::NE, 22421.7}, // PangaMA: 22421.7, Matlab: 22424.9
-    {Gas::AR, 22386.5}, // PangaMA: 22386.5, Matlab: 22392.6
-    {Gas::KR, 22351.2}, // PangaMA: 22351.2, Matlab: 22352.9
-    {Gas::XE, 22280.4}, // PangaMA: 22280.4, Matlab: 22257.0
+    {Gas::HE, 22425.8703182828}, // Porcelli: 22436.4 
+    {Gas::NE, 22424.8703182828}, //           22421.7
+    {Gas::AR, 22392.5703182828}, //           22386.5
+    {Gas::KR, 22352.8703182828}, //           22351.2
+    {Gas::XE, 22256.9703182828}, //           22280.4
 };
 double PhysicalProperties::GetMolarVolume(GasType gas)
 {
     return PhysicalProperties::molar_volumes_new.find(gas)->second;
 }
 
-const double PhysicalProperties::molar_volume_ideal_gas_ = 22414.1;
+
 
 //! \todo Eine Lösung finden für das doppelte definieren des Xenon-Werts.
 const std::map<GasType, double> PhysicalProperties::dry_air_volume_fractions_ = {

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -130,8 +130,8 @@ double PhysicalProperties::CalcSaturationVaporPressureDerivedByT_Dickson(double 
     //Calculate value of Wagner polynomial
     double Wagner = -7.85951783*temp_mod +1.84408259*pow(temp_mod, 1.5) -11.7866497*pow(temp_mod, 3) +22.6807411*pow(temp_mod, 3.5) -15.9618719*pow(temp_mod, 4) +1.80122502*pow(temp_mod, 7.5);
     double WagnerDerivedByTmod = -7.85951783+ 1.5* 1.84408259*pow(temp_mod, 0.5) - 3* 11.7866497*pow(temp_mod, 2) + 3.5* 22.6807411*pow(temp_mod, 2.5) - 4* 15.9618719*pow(temp_mod, 3) + 7.5* 1.80122502*pow(temp_mod, 6.5);
-    double WagnerDerivedByT = 1/647.096 * WagnerDerivedByTmod;
-    return CalcSaturationVaporPressure_Dickson(T_c, S)* (WagnerDerivedByT * 647.096 / temp_K - Wagner * 647.096 / pow(T_c,2));
+    double WagnerDerivedByT = - 1/647.096 * WagnerDerivedByTmod;
+    return CalcSaturationVaporPressure_Dickson(T_c, S)* (WagnerDerivedByT * 647.096 / temp_K - Wagner * 647.096 / pow(temp_K,2));
 }
 double PhysicalProperties::CalcSaturationVaporPressureDerivedByS_Dickson(double T_c, double S)
 {

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -59,6 +59,8 @@ const std::map<GasType, std::pair<double, double>>
 // const double PhysicalProperties::R = 0.082058;
 const double PhysicalProperties::R = 8.3143;
 
+//Benson and Krause 1980; Kipfer et al. 2002
+//Coefficients for the calculation of 3He/4He
 const double PhysicalProperties::r1_ = -0.0299645;
 const double PhysicalProperties::r2_ = 19.8715;
 const double PhysicalProperties::r3_ = -1833.92;

--- a/src/core/models/physicalproperties.cpp
+++ b/src/core/models/physicalproperties.cpp
@@ -35,6 +35,19 @@ const std::map<GasType, std::vector<double> > PhysicalProperties::virial_coeffic
 const std::map<GasType, double> PhysicalProperties::molar_volumes_ =
     PhysicalProperties::CalculateMolarVolumes(PhysicalProperties::virial_coefficient_parameters_);
 
+// (molare Volumen aus Porcelli, Noble Gases in Geochemistry and Cosmochemistry)
+const std::map<GasType, double> PhysicalProperties::molar_volumes_new = { 
+    {Gas::HE, 22436.4}, // PangaMA: 22436.4, Matlab: 22425.9
+    {Gas::NE, 22421.7}, // PangaMA: 22421.7, Matlab: 22424.9
+    {Gas::AR, 22386.5}, // PangaMA: 22386.5, Matlab: 22392.6
+    {Gas::KR, 22351.2}, // PangaMA: 22351.2, Matlab: 22352.9
+    {Gas::XE, 22280.4}, // PangaMA: 22280.4, Matlab: 22257.0
+};
+double PhysicalProperties::GetMolarVolume(GasType gas)
+{
+    return PhysicalProperties::molar_volumes_new.find(gas)->second;
+}
+
 const double PhysicalProperties::molar_volume_ideal_gas_ = 22414.1;
 
 //! \todo Eine Lösung finden für das doppelte definieren des Xenon-Werts.

--- a/src/core/models/physicalproperties.h
+++ b/src/core/models/physicalproperties.h
@@ -39,10 +39,10 @@ public:
       \param T_c Temperatur in °C.
       \return Sättigungsdampfdruck in atm.
       */
-    static double CalcSaturationVaporPressure(double T_c);
+    static double CalcSaturationVaporPressure_Gill(double T_c);
 
-    //! Berechnet die Ableitung des \ref CalcSaturationVaporPressure "Sättigungsdampfdrucks" von Wasser.
-    static double CalcSaturationVaporPressureDerivative(double T_c);
+    //! Berechnet die Ableitung des \ref CalcSaturationVaporPressure_Gill "Sättigungsdampfdrucks" von Wasser.
+    static double CalcSaturationVaporPressureDerivative_Gill(double T_c);
 
     //! Berechnet die Dichte von Wasser für die gegebenen Bedingungen.
     /*!

--- a/src/core/models/physicalproperties.h
+++ b/src/core/models/physicalproperties.h
@@ -130,7 +130,11 @@ public:
     //! Ableitung von Req nach S.
     static double CalcReqDerivedByS(double t, double s);
 
-    //! Molvolumina der Edelgase zur Umrechnung.
+    //! Molvolumina der Edelgase zur Umrechnung von Jenkins und Clever Löslichkeiten.
+    /*!
+     * based on Dymond and Smith, 1980
+     * in ccSTP/mol
+     */
     static double GetMolarVolume(GasType gas);
 
 //     //! Gaskonstante in atm*l/(mol*K).
@@ -188,7 +192,7 @@ private:
     //! Molvolumina der Edelgase, berechnet mit CalculateMolarVolumes.
     static const std::map<GasType, double> molar_volumes_;
     
-    //! Molvolumina der Edelgase, zum Vergleichen (WIP).
+    //! Molvolumina der Edelgase, basierend auf Dymond and Smith (1980).
     static const std::map<GasType, double> molar_volumes_new;
 
     //! Volumenanteile der Edelgase in trockener Luft.

--- a/src/core/models/physicalproperties.h
+++ b/src/core/models/physicalproperties.h
@@ -130,6 +130,9 @@ public:
     //! Ableitung von Req nach S.
     static double CalcReqDerivedByS(double t, double s);
 
+    //! Molvolumina der Edelgase zur Umrechnung.
+    static double GetMolarVolume(GasType gas);
+
 //     //! Gaskonstante in atm*l/(mol*K).
 //     static const double R;
 
@@ -184,6 +187,9 @@ private:
 
     //! Molvolumina der Edelgase, berechnet mit CalculateMolarVolumes.
     static const std::map<GasType, double> molar_volumes_;
+    
+    //! Molvolumina der Edelgase, zum Vergleichen (WIP).
+    static const std::map<GasType, double> molar_volumes_new;
 
     //! Volumenanteile der Edelgase in trockener Luft.
     static const std::map<GasType, double> dry_air_volume_fractions_;

--- a/src/core/models/physicalproperties.h
+++ b/src/core/models/physicalproperties.h
@@ -40,9 +40,18 @@ public:
       \return Sättigungsdampfdruck in atm.
       */
     static double CalcSaturationVaporPressure_Gill(double T_c);
+    //! Berechnet den Sättigungsdampfdruck von Wasser.
+    /*!
+      Berechnung nach Dickson 2007, Guide to Best Practices for Ocean CO2 Measurements. 
+      Basierend auf einem Skript von Roberta Hamme (vpress Version 2.0 : 27 October 2012).
+      */
+    static double CalcSaturationVaporPressure_Dickson(double T_c, double S);
 
     //! Berechnet die Ableitung des \ref CalcSaturationVaporPressure_Gill "Sättigungsdampfdrucks" von Wasser.
     static double CalcSaturationVaporPressureDerivative_Gill(double T_c);
+    //! Berechnet die Ableitungen des \ref CalcSaturationVaporPressure_Dickson "Sättigungsdampfdrucks" von Wasser.
+    static double CalcSaturationVaporPressureDerivedByT_Dickson(double T_c, double S);
+    static double CalcSaturationVaporPressureDerivedByS_Dickson(double T_c, double S);
 
     //! Berechnet die Dichte von Wasser für die gegebenen Bedingungen.
     /*!

--- a/src/core/models/physicalproperties.h
+++ b/src/core/models/physicalproperties.h
@@ -90,7 +90,7 @@ public:
       */
     static double ConvertToMole(double ccstp, GasType gas);
 
-    //! Wandelt Gaskonzentrationen im Wasser von mol/l in ccSTP/g um.
+    //! Wandelt Gaskonzentrationen im Wasser von ccSTP/g in mol/l um.
     /*!
       Da das Wasservolumen keine Stoffmenge angibt müssen Druck, Salinität und Temperatur mit angegeben werden.
       \param ccstp_g Konzentration in ccSTP/g.

--- a/src/core/models/weissmethod.cpp
+++ b/src/core/models/weissmethod.cpp
@@ -65,7 +65,7 @@ void WeissMethod::CalculateDerivatives(
     const double t_k = x->T() + 273.15;
 
     // Sättigungsdampfdruck.
-    const double p_w = PhysicalProperties::CalcSaturationVaporPressure(x->T());
+    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Gill(x->T());
 
     // (p - pw) / (1 - pw)
     const double frac = (x->p() - p_w) / (1. - p_w);
@@ -108,7 +108,7 @@ void WeissMethod::CalculateDerivatives(
                            +
 
                            (x->p() - 1.) / std::pow(1. - p_w, 2.) * //Ableitung von "frac"
-                           PhysicalProperties::CalcSaturationVaporPressureDerivative(x->T()));
+                           PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(x->T()));
             break;
 
         case Weiss::OTHER:
@@ -166,7 +166,7 @@ double WeissMethod::CalculateConcentration(double p, double S, double T, GasType
                                  " Weiss method.");
 
     // Sättigungsdampfdruck in atm.
-    const double p_w = PhysicalProperties::CalcSaturationVaporPressure(T);
+    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Gill(T);
 
     // Partialdruck der trockenen Luft.
     const double p_dry = p - p_w;

--- a/src/core/models/weissmethod.cpp
+++ b/src/core/models/weissmethod.cpp
@@ -24,9 +24,9 @@
 
 #include "weissmethod.h"
 
-const std::string WeissMethod::NAME = "WeissClever";
+const std::string WeissMethod::NAME = "WeissClever"; // Achtung, der Name wir in combinedmodel.cpp zum abrufen verwendet
 
-std::string WeissMethod::GetCEqMethodName() const   //WIP: Verwendet?
+std::string WeissMethod::GetCEqMethodName() const
 {
     return WeissMethod::NAME;
 }

--- a/src/core/models/weissmethod.cpp
+++ b/src/core/models/weissmethod.cpp
@@ -65,7 +65,7 @@ void WeissMethod::CalculateDerivatives(
     const double t_k = x->T() + 273.15;
 
     // Sättigungsdampfdruck.
-    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Gill(x->T());
+    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Dickson(x->T(), x->S());
 
     // (p - pw) / (1 - pw)
     const double frac = (x->p() - p_w) / (1. - p_w);
@@ -89,7 +89,13 @@ void WeissMethod::CalculateDerivatives(
             derivative = exponential * frac *
                           (s1[gas_for_calculations] +
                            s2[gas_for_calculations] * t_k +
-                           s3[gas_for_calculations] * t_k * t_k);
+                           s3[gas_for_calculations] * t_k * t_k)
+                           
+                           + //Verwendung von VaporPressure_Dickson mit Salinity Abhängigkeit:
+                           exponential * 
+                           (x->p() - 1.) / std::pow(1. - p_w, 2.) * //Ableitung von "frac"
+                           PhysicalProperties::CalcSaturationVaporPressureDerivedByS_Dickson(x->T(), x->S())
+                           ;
             break;
 
         case Weiss::T:
@@ -108,7 +114,8 @@ void WeissMethod::CalculateDerivatives(
                            +
 
                            (x->p() - 1.) / std::pow(1. - p_w, 2.) * //Ableitung von "frac"
-                           PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(x->T()));
+                           PhysicalProperties::CalcSaturationVaporPressureDerivedByT_Dickson(x->T(), x->S())
+                           );
             break;
 
         case Weiss::OTHER:
@@ -166,7 +173,7 @@ double WeissMethod::CalculateConcentration(double p, double S, double T, GasType
                                  " Weiss method.");
 
     // Sättigungsdampfdruck in atm.
-    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Gill(T);
+    const double p_w = PhysicalProperties::CalcSaturationVaporPressure_Dickson(T, S);
 
     // Partialdruck der trockenen Luft.
     const double p_dry = p - p_w;

--- a/src/core/models/weissmethod.cpp
+++ b/src/core/models/weissmethod.cpp
@@ -24,6 +24,13 @@
 
 #include "weissmethod.h"
 
+const std::string WeissMethod::NAME = "Weiss,Clever(Xe)";
+
+std::string WeissMethod::GetCEqMethodName() const   //WIP: Verwendet?
+{
+    return WeissMethod::NAME;
+}
+
 WeissMethod::WeissMethod(std::shared_ptr<ParameterManager> manager)
 {
     RegisterParameters(manager,

--- a/src/core/models/weissmethod.h
+++ b/src/core/models/weissmethod.h
@@ -87,6 +87,10 @@ public:
                                          double T,
                                          GasType gas);
 
+    static const std::string NAME;
+    
+    std::string GetCEqMethodName() const;  //WIP: Verwendet?
+
 private:
 
     //! Berechnet die exp-Funktion aus der Weiss-Formel.

--- a/src/core/models/weissmethod.h
+++ b/src/core/models/weissmethod.h
@@ -89,7 +89,7 @@ public:
 
     static const std::string NAME;
     
-    std::string GetCEqMethodName() const;  //WIP: Verwendet?
+    std::string GetCEqMethodName() const; 
 
 private:
 

--- a/src/core/models/weissmethodfactory.cpp
+++ b/src/core/models/weissmethodfactory.cpp
@@ -1,0 +1,37 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "weissmethod.h"
+
+#include "weissmethodfactory.h"
+
+WeissMethodFactory::~WeissMethodFactory()
+{
+}
+
+std::shared_ptr<CEqCalculationMethod> WeissMethodFactory::CreateCEqMethod(
+    std::shared_ptr<ParameterManager> manager
+) const
+{
+    return std::make_shared<WeissMethod>(manager);
+}
+
+std::string WeissMethodFactory::GetCEqMethodName() const
+{
+    return WeissMethod::NAME;
+}

--- a/src/core/models/weissmethodfactory.h
+++ b/src/core/models/weissmethodfactory.h
@@ -25,8 +25,8 @@ class WeissMethodFactory : public CEqMethodFactory
 {
 public:
     ~WeissMethodFactory();
-    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod( //WIP: (Frage) Warum nicht direkt WeissMethod statt CEqCalculationMethod
-        std::shared_ptr<ParameterManager> manager) const; //WIP: Problem: ParameterManager scheint hier noch zu fehlen als include
+    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod(
+        std::shared_ptr<ParameterManager> manager) const;
     std::string GetCEqMethodName() const;
 };
 

--- a/src/core/models/weissmethodfactory.h
+++ b/src/core/models/weissmethodfactory.h
@@ -1,0 +1,33 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef WEISSMETHODFACTORY_H
+#define WEISSMETHODFACTORY_H
+
+#include "ceqmethodfactory.h"
+
+class WeissMethodFactory : public CEqMethodFactory
+{
+public:
+    ~WeissMethodFactory();
+    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod( //WIP: (Frage) Warum nicht direkt WeissMethod statt CEqCalculationMethod
+        std::shared_ptr<ParameterManager> manager) const; //WIP: Problem: ParameterManager scheint hier noch zu fehlen als include
+    std::string GetCEqMethodName() const;
+};
+
+#endif // WEISSMETHODFACTORY_H

--- a/src/core/testing/fitting/test_nobleparametermap.cpp
+++ b/src/core/testing/fitting/test_nobleparametermap.cpp
@@ -29,12 +29,13 @@
 #include "core/models/combinedmodelfactory.h"
 
 #include "testing/models/testmodel.h"
+#include "testing/models/testceqmethod.h"
 
 BOOST_AUTO_TEST_SUITE(NobleParameterMap_tests)
 
 BOOST_AUTO_TEST_CASE(Constructor)
 {
-    CombinedModelFactory factory(new TestFactory());
+    CombinedModelFactory factory(new TestFactory(), new TestCEqFactory());
     std::shared_ptr<CombinedModel> model(factory.CreateModel());
     std::vector<std::string> parameters(model->GetParameterNamesInOrder());
     std::map<std::string, unsigned> name_map;

--- a/src/core/testing/models/CMakeLists.txt
+++ b/src/core/testing/models/CMakeLists.txt
@@ -34,6 +34,7 @@ set(models_TESTS
     test_weissderivativecollector.cpp
     test_weissmethod.cpp
     test_weissparameteraccessor.cpp
+    test_jenkinsmethod.cpp
     )
 
 add_executable(test_models ${models_TESTS})

--- a/src/core/testing/models/manualtest_models.cpp
+++ b/src/core/testing/models/manualtest_models.cpp
@@ -34,7 +34,7 @@ namespace manualtesting
         }
 
         std::shared_ptr<ParameterManager> manager;
-        WeissMethod method; //Change tested method
+        JenkinsMethod method; //Change tested method
         std::shared_ptr<ParameterAccessor> accessor;
         Eigen::VectorXd vec;
 
@@ -159,31 +159,29 @@ namespace manualtesting
             std::cout << std::endl;
         }
     }
-    void printconcentrations(){
-        double p_; double S_; double T_; double A; double F; double c;
-        p_ = 1; 
-        S_ = .1;
-        T_ = 10;
-        A = .01;
-        F = .2; 
-        c = 1.31506883127e-08  ;
-        printf("%.15g", c+(1-F)*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/(1+F*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/c)); std::cout << std::endl;
+    // void printconcentrations(){
+    //     double p_; double S_; double T_; double A; double F; double c;
+    //     p_ = 1; 
+    //     S_ = .1;
+    //     T_ = 10;
+    //     A = .01;
+    //     F = .2; 
+    //     c = 1.31506883127e-08  ;
+    //     printf("%.15g", c+(1-F)*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/(1+F*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/c)); std::cout << std::endl;
 
-
-        p_ = 2;
-        S_ = 1;
-        T_ = 0;
-        A = 3;
-        F = 4;
-        c = 2.47039861698971e-07 ;
-        printf("%.15g", c+(1-F)*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/(1+F*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/c)); std::cout << std::endl;
-
-    }   
+    //     p_ = 2;
+    //     S_ = 1;
+    //     T_ = 0;
+    //     A = 3;
+    //     F = 4;
+    //     c = 2.47039861698971e-07 ;
+    //     printf("%.15g", c+(1-F)*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/(1+F*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/c)); std::cout << std::endl;
+    // }   
 
     void test(){
-        // manualtesting::test_derivatives_ceqmethod();
-        // test_derivatives_physicalproperties();
-        printequilibriumconcentrations();
-        printconcentrations();
+        manualtesting::test_derivatives_ceqmethod();
+        test_derivatives_physicalproperties();
+        // printequilibriumconcentrations();
+        // printconcentrations();
     }
 }

--- a/src/core/testing/models/manualtest_models.cpp
+++ b/src/core/testing/models/manualtest_models.cpp
@@ -34,7 +34,7 @@ namespace manualtesting
         }
 
         std::shared_ptr<ParameterManager> manager;
-        CleverMethod method; //Change tested method
+        WeissMethod method; //Change tested method
         std::shared_ptr<ParameterAccessor> accessor;
         Eigen::VectorXd vec;
 
@@ -57,8 +57,8 @@ namespace manualtesting
         indices.push_back(fxt.manager->GetParameterIndex("T"));
         dcol->SetDerivativesAndResultsVector(derivatives, indices);
 
-        GasType usedgas = Gas::XE; // WIP: loop different gases
-
+        GasType usedgas = Gas::KR; // WIP: loop different gases
+        
         double xi;
         std::cout << "Weiss/Jenkins T (Gas " << usedgas << ")" << std::endl;  //Param
         for(xi=0; xi<35; xi++) {
@@ -112,6 +112,17 @@ namespace manualtesting
             std::cout << std::endl;
         }
     }
+    void printequilibriumconcentrations(){
+        Fixture fxt;
+        fxt.p = 1; 
+        fxt.S = .1;
+        fxt.T = 10;
+        printf("%.15g ",fxt.method.CalculateConcentration(fxt.accessor, Gas::KR) ); std::cout << std::endl;
+        fxt.p = 2;
+        fxt.S = 1;
+        fxt.T = 0;
+        printf("%.15g ",fxt.method.CalculateConcentration(fxt.accessor, Gas::KR) ); std::cout << std::endl;
+    }
     void test_derivatives_physicalproperties(){
         double xi;
         double s_=1.1;
@@ -149,35 +160,30 @@ namespace manualtesting
         }
     }
     void printconcentrations(){
-        double p_ = 1.01;
-        double S_ = 0;
-        double T_ = 20;
-        double b = 1 /((p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_)))
-        *((p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_)))
-        *PhysicalProperties::GetMolarVolume(Gas::XE)/22280.4;
-        printf("%.15g", 9.61329873652310e-9 * b); std::cout << std::endl;
+        double p_; double S_; double T_; double A; double F; double c;
+        p_ = 1; 
+        S_ = .1;
+        T_ = 10;
+        A = .01;
+        F = .2; 
+        c = 1.31506883127e-08  ;
+        printf("%.15g", c+(1-F)*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/(1+F*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/c)); std::cout << std::endl;
 
-        p_ = .99;
-        S_ = .001;
-        T_ = 23;
-        b = 1 /((p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_)))
-        *((p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_)))
-        *PhysicalProperties::GetMolarVolume(Gas::XE)/22280.4;
-        printf("%.15g", 8.61872441480665e-9 * b); std::cout << std::endl;
 
-        p_ = 4;
-        S_ = 5;
-        T_ = 6;
-        b = 1 /((p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_)))
-        *((p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_)))
-        *PhysicalProperties::GetMolarVolume(Gas::XE)/22280.4;
-        printf("%.15g", 5.88642611001335e-8 * b); std::cout << std::endl;
+        p_ = 2;
+        S_ = 1;
+        T_ = 0;
+        A = 3;
+        F = 4;
+        c = 2.47039861698971e-07 ;
+        printf("%.15g", c+(1-F)*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/(1+F*A*PhysicalProperties::GetDryAirVolumeFraction(Gas::KR)/c)); std::cout << std::endl;
 
     }   
 
     void test(){
-        manualtesting::test_derivatives_ceqmethod();
+        // manualtesting::test_derivatives_ceqmethod();
         // test_derivatives_physicalproperties();
+        printequilibriumconcentrations();
         printconcentrations();
     }
 }

--- a/src/core/testing/models/manualtest_models.cpp
+++ b/src/core/testing/models/manualtest_models.cpp
@@ -148,8 +148,52 @@ namespace manualtesting
             std::cout << std::endl;
         }
     }
+    void printconcentrations(){
+        double p_ = 2;
+        double T_ = 0;
+        double S_ = 1;
+        double b = 1 /(
+            (p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))
+        )*(
+            (p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))
+        );
+        printf("%.15g", 9.77748738846232e-08 * b);  std::cout << std::endl;
+        printf("%.15g", 4.48172212527456e-07 * b); std::cout << std::endl;
+        printf("%.15g", 9.91230382674763e-04 * b); std::cout << std::endl;
+        printf("%.15g", 2.47039748481394e-07 * b); std::cout << std::endl;
+        printf("%.15g",   1.328780665567e-13 * b); std::cout << std::endl;
+
+        T_ = 10;
+        S_ = .1;
+        p_ = 1;
+        b = 1 /(
+            (p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))
+        )*(
+            (p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))
+        );        printf("%.15g", 4.64269706836073e-08 * b); std::cout << std::endl;
+        printf("%.15g", 2.01619787901304e-07 * b); std::cout << std::endl;
+        printf("%.15g", 3.85849249750526e-04 * b); std::cout << std::endl;
+        printf("%.15g", 9.09654355930234e-08 * b); std::cout << std::endl;
+        printf("%.15g",   6.315021552700E-14 * b); std::cout << std::endl;
+
+
+        T_ = 20;
+        S_ = 0;
+        p_ = 1.01;
+        b = 1 /(
+            (p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))
+        )*(
+            (p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))
+        );
+        printf("%.15g", 4.52241473452391e-08 * b); std::cout << std::endl;
+        printf("%.15g", 1.86998524534805e-07 * b); std::cout << std::endl;
+        printf("%.15g", 3.15103538968795e-04 * b); std::cout << std::endl;
+        printf("%.15g", 7.03793929300997e-08 * b); std::cout << std::endl;
+        printf("%.15g",   6.156710522179E-14 * b); std::cout << std::endl;
+    }
     void test(){
-        manualtesting::test_derivatives_ceqmethod();
-        test_derivatives_physicalproperties();
+        // manualtesting::test_derivatives_ceqmethod();
+        // test_derivatives_physicalproperties();
+        printconcentrations();
     }
 }

--- a/src/core/testing/models/manualtest_models.cpp
+++ b/src/core/testing/models/manualtest_models.cpp
@@ -1,0 +1,114 @@
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+#include <Eigen/Core>
+
+#include <memory>
+
+#include <stdexcept>
+
+#include "core/models/parametermanager.h"
+#include "core/models/jenkinsmethod.h"
+#include "core/models/weissmethod.h"
+
+namespace manualtesting
+{
+    struct Fixture
+    {
+        Fixture() :
+            manager(new ParameterManager()), //WIP: Warum mit new einführen?
+            method(manager),
+            accessor(method.GetParameterAccessor()),
+            vec(manager->GetParametersInOrder().size()),
+            T(vec[manager->GetParameterIndex("T")]),
+            S(vec[manager->GetParameterIndex("S")]),
+            p(vec[manager->GetParameterIndex("p")])
+        {
+            accessor->SetVectorReference(vec);
+        }
+
+        ~Fixture()
+        {
+        }
+
+        std::shared_ptr<ParameterManager> manager;
+        WeissMethod method;
+        std::shared_ptr<ParameterAccessor> accessor;
+        Eigen::VectorXd vec;
+
+        double& T;
+        double& S;
+        double& p;
+    };
+
+
+    void test_ceqmethod(){
+        Fixture fxt;
+        fxt.T = 0;
+        fxt.S = 1;
+        fxt.p = 2;
+
+        // Stuff for the Derivatives
+        std::shared_ptr<DerivativeCollector> dcol(fxt.method.GetDerivativeCollector());
+        Eigen::RowVectorXd derivatives(5);
+        std::vector<int> indices;
+        indices.push_back(17);
+        indices.push_back(fxt.manager->GetParameterIndex("S"));
+        indices.push_back(fxt.manager->GetParameterIndex("p"));
+        indices.push_back(42);
+        indices.push_back(fxt.manager->GetParameterIndex("T"));
+        dcol->SetDerivativesAndResultsVector(derivatives, indices);
+
+
+        // Test loops
+        // WIP: loop über gase
+        double xi;
+        std::cout << "T" << std::endl;
+        for(xi=0; xi<35; xi++) {
+            fxt.T=xi;
+            printf("%.3g ",fxt.T );
+            Gas::GasType gas_ = Gas::StringToGasType("xe");
+            fxt.method.CalculateDerivatives(fxt.accessor, dcol, Gas::HE); 
+            double c1 = fxt.method.CalculateConcentration(fxt.accessor, Gas::HE);
+            double b = 1E-08;
+            fxt.T=xi+b;
+            double c2 = fxt.method.CalculateConcentration(fxt.accessor, Gas::HE);
+            double a = c2-c1;
+            printf("%.20g ", a/b );
+            printf("%.20g", derivatives[4/*T*/]);
+            std::cout << std::endl;
+        }
+        std::cout << "p" << std::endl;
+        for(xi=0; xi<100; xi++) {
+            fxt.p=xi/100;
+            printf("%.3g ",fxt.T );
+            fxt.method.CalculateDerivatives(fxt.accessor, dcol, Gas::HE); 
+            double c1 = fxt.method.CalculateConcentration(fxt.accessor, Gas::HE);
+            double b = 1E-08;
+            fxt.p=xi/100+b;
+            double c2 = fxt.method.CalculateConcentration(fxt.accessor, Gas::HE);
+            double a = c2-c1;
+            printf("%.20g ", a/b );
+            printf("%.20g", derivatives[2/*p*/]);
+            std::cout << std::endl;
+        }
+        std::cout << "p" << std::endl;
+        for(xi=0; xi<35; xi++) {
+            fxt.S=xi;
+            printf("%.3g ",fxt.T );
+            fxt.method.CalculateDerivatives(fxt.accessor, dcol, Gas::HE); 
+            double c1 = fxt.method.CalculateConcentration(fxt.accessor, Gas::HE);
+            double b = 1E-08;
+            fxt.S=xi+b;
+            double c2 = fxt.method.CalculateConcentration(fxt.accessor, Gas::HE);
+            double a = c2-c1;
+            printf("%.20g ", a/b );
+            printf("%.20g", derivatives[1/*S*/]);
+            std::cout << std::endl;
+        }
+    }
+    void test(){
+        manualtesting::test_ceqmethod();
+    }
+}

--- a/src/core/testing/models/manualtest_models.cpp
+++ b/src/core/testing/models/manualtest_models.cpp
@@ -34,7 +34,7 @@ namespace manualtesting
         }
 
         std::shared_ptr<ParameterManager> manager;
-        JenkinsMethod method; //Change tested method
+        CleverMethod method; //Change tested method
         std::shared_ptr<ParameterAccessor> accessor;
         Eigen::VectorXd vec;
 
@@ -57,7 +57,7 @@ namespace manualtesting
         indices.push_back(fxt.manager->GetParameterIndex("T"));
         dcol->SetDerivativesAndResultsVector(derivatives, indices);
 
-        GasType usedgas = Gas::HE3; // WIP: loop different gases
+        GasType usedgas = Gas::XE; // WIP: loop different gases
 
         double xi;
         std::cout << "Weiss/Jenkins T (Gas " << usedgas << ")" << std::endl;  //Param
@@ -149,50 +149,34 @@ namespace manualtesting
         }
     }
     void printconcentrations(){
-        double p_ = 2;
-        double T_ = 0;
-        double S_ = 1;
-        double b = 1 /(
-            (p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))
-        )*(
-            (p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))
-        );
-        printf("%.15g", 9.77748738846232e-08 * b);  std::cout << std::endl;
-        printf("%.15g", 4.48172212527456e-07 * b); std::cout << std::endl;
-        printf("%.15g", 9.91230382674763e-04 * b); std::cout << std::endl;
-        printf("%.15g", 2.47039748481394e-07 * b); std::cout << std::endl;
-        printf("%.15g",   1.328780665567e-13 * b); std::cout << std::endl;
+        double p_ = 1.01;
+        double S_ = 0;
+        double T_ = 20;
+        double b = 1 /((p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_)))
+        *((p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_)))
+        *PhysicalProperties::GetMolarVolume(Gas::XE)/22280.4;
+        printf("%.15g", 9.61329873652310e-9 * b); std::cout << std::endl;
 
-        T_ = 10;
-        S_ = .1;
-        p_ = 1;
-        b = 1 /(
-            (p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))
-        )*(
-            (p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))
-        );        printf("%.15g", 4.64269706836073e-08 * b); std::cout << std::endl;
-        printf("%.15g", 2.01619787901304e-07 * b); std::cout << std::endl;
-        printf("%.15g", 3.85849249750526e-04 * b); std::cout << std::endl;
-        printf("%.15g", 9.09654355930234e-08 * b); std::cout << std::endl;
-        printf("%.15g",   6.315021552700E-14 * b); std::cout << std::endl;
+        p_ = .99;
+        S_ = .001;
+        T_ = 23;
+        b = 1 /((p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_)))
+        *((p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_)))
+        *PhysicalProperties::GetMolarVolume(Gas::XE)/22280.4;
+        printf("%.15g", 8.61872441480665e-9 * b); std::cout << std::endl;
 
+        p_ = 4;
+        S_ = 5;
+        T_ = 6;
+        b = 1 /((p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_)))
+        *((p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_)))
+        *PhysicalProperties::GetMolarVolume(Gas::XE)/22280.4;
+        printf("%.15g", 5.88642611001335e-8 * b); std::cout << std::endl;
 
-        T_ = 20;
-        S_ = 0;
-        p_ = 1.01;
-        b = 1 /(
-            (p_-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Gill(T_))
-        )*(
-            (p_-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))/(1-PhysicalProperties::CalcSaturationVaporPressure_Dickson(T_, S_))
-        );
-        printf("%.15g", 4.52241473452391e-08 * b); std::cout << std::endl;
-        printf("%.15g", 1.86998524534805e-07 * b); std::cout << std::endl;
-        printf("%.15g", 3.15103538968795e-04 * b); std::cout << std::endl;
-        printf("%.15g", 7.03793929300997e-08 * b); std::cout << std::endl;
-        printf("%.15g",   6.156710522179E-14 * b); std::cout << std::endl;
-    }
+    }   
+
     void test(){
-        // manualtesting::test_derivatives_ceqmethod();
+        manualtesting::test_derivatives_ceqmethod();
         // test_derivatives_physicalproperties();
         printconcentrations();
     }

--- a/src/core/testing/models/manualtest_models.cpp
+++ b/src/core/testing/models/manualtest_models.cpp
@@ -18,7 +18,7 @@ namespace manualtesting
     struct Fixture
     {
         Fixture() :
-            manager(new ParameterManager()), //WIP: Warum mit new einführen?
+            manager(new ParameterManager()),
             method(manager),
             accessor(method.GetParameterAccessor()),
             vec(manager->GetParametersInOrder().size()),
@@ -57,7 +57,7 @@ namespace manualtesting
         indices.push_back(fxt.manager->GetParameterIndex("T"));
         dcol->SetDerivativesAndResultsVector(derivatives, indices);
 
-        GasType usedgas = Gas::KR; // WIP: loop different gases
+        GasType usedgas = Gas::KR; //(todo) loop different gases
         
         double xi;
         std::cout << "Weiss/Jenkins T (Gas " << usedgas << ")" << std::endl;  //Param

--- a/src/core/testing/models/test_cemodel.cpp
+++ b/src/core/testing/models/test_cemodel.cpp
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(CalculateConcentration)
                           clever->CalculateConcentration(clever_accessor, Gas::XE),
                           ce_accessor,
                           Gas::XE),
-                      1.38516280692637e-8,
+                      1.38375996198047e-08,
                       1e-6);
 
     A = 31337;
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(CalculateConcentration)
                           weiss->CalculateConcentration(weiss_accessor, Gas::KR),
                           ce_accessor,
                           Gas::KR),
-                      6.5046455922903e-8,
+                      6.50464872129845e-08,
                       1e-6);
 }
 

--- a/src/core/testing/models/test_clevermethod.cpp
+++ b/src/core/testing/models/test_clevermethod.cpp
@@ -73,17 +73,17 @@ BOOST_AUTO_TEST_CASE(CalculateConcentration)
     p = 1.01;
     S = 0;
     T = 20;
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 9.61329873652310e-9, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 9.60291390689642e-09, 1e-6);
 
     p = .99;
     S = .001;
     T = 23;
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 8.61872441480665e-9, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 8.60938089884059e-09, 1e-6);
 
     p = 4;
     S = 5;
     T = 6;
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 5.88642611001335e-8, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 5.88025826763174e-08, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(CalculateDerivatives)

--- a/src/core/testing/models/test_combinedmodel.cpp
+++ b/src/core/testing/models/test_combinedmodel.cpp
@@ -28,13 +28,15 @@
 #include "core/models/combinedmodel.h"
 
 #include "testmodel.h"
+#include "testceqmethod.h"
 
 BOOST_AUTO_TEST_SUITE(CombinedModel_tests)
 
 BOOST_AUTO_TEST_CASE(ParameterNotFound)
-{
+{   
     ModelFactory* factory(new TestFactory());
-    CombinedModel model(factory);
+    CEqMethodFactory* ceqmethod_factory(new TestCEqFactory());
+    CombinedModel model(factory, ceqmethod_factory);
 
     BOOST_CHECK_NO_THROW(model.GetParameterIndex("a"));
     BOOST_CHECK_NO_THROW(model.GetParameterIndex("b"));
@@ -51,7 +53,8 @@ BOOST_AUTO_TEST_CASE(ParameterNotFound)
 BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
 {
     ModelFactory* factory(new TestFactory());
-    CombinedModel model(factory);
+    CEqMethodFactory* ceqmethod_factory(new TestCEqFactory());
+    CombinedModel model(factory, ceqmethod_factory);
 
     std::vector<int> indices;
     indices.push_back(model.GetParameterIndex("a"));
@@ -148,7 +151,8 @@ BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
 BOOST_AUTO_TEST_CASE(SanityChecks)
 {
     ModelFactory* factory(new TestFactory());
-    CombinedModel model(factory);
+    CEqMethodFactory* ceqmethod_factory(new TestCEqFactory());
+    CombinedModel model(factory, ceqmethod_factory);
 
     Eigen::VectorXd parameters(3);
     BOOST_CHECK_THROW(model.SetParameters(parameters), std::invalid_argument);

--- a/src/core/testing/models/test_combinedmodel.cpp
+++ b/src/core/testing/models/test_combinedmodel.cpp
@@ -86,13 +86,13 @@ BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
 
     BOOST_CHECK_CLOSE(
                 model.CalculateEquilibriumConcentration(Gas::NE),
-                1.86998524534805e-07,
+                1.86998579479645e-07,
                 1e-6
                 );
 
     BOOST_CHECK_CLOSE(
                 model.CalculateConcentration(Gas::NE),
-                (a + b + c + T) * 1.86998524534805e-07,
+                (a + b + c + T) * 1.86998579479645e-07,
                 1e-6
                 );
 
@@ -102,9 +102,9 @@ BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
     BOOST_CHECK_CLOSE(derivs[0]/*a*/, 0, 1e-14);
     BOOST_CHECK_CLOSE(derivs[1]/*b*/, 0, 1e-14);
     BOOST_CHECK_CLOSE(derivs[2]/*c*/, 0, 1e-14);
-    BOOST_CHECK_CLOSE(derivs[3]/*T*/, -1.39367393359350e-10, 1e-8);
-    BOOST_CHECK_CLOSE(derivs[4]/*S*/, -2.35966230954645e-10, 1e-8);
-    BOOST_CHECK_CLOSE(derivs[5]/*p*/,  4.58224843117053e-8 , 1e-8);
+    BOOST_CHECK_CLOSE(derivs[3]/*T*/, -1.39366806606821e-10, 1e-8);
+    BOOST_CHECK_CLOSE(derivs[4]/*S*/, -2.35971963482711e-10, 1e-8);
+    BOOST_CHECK_CLOSE(derivs[5]/*p*/,  4.58238131136642e-08 , 1e-8);
 
     derivs = model.CalculateDerivatives(Gas::HE);
 
@@ -112,19 +112,19 @@ BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
     BOOST_CHECK_CLOSE(derivs[0]/*a*/, 1, 1e-14);
     BOOST_CHECK_CLOSE(derivs[1]/*b*/, 2, 1e-14);
     BOOST_CHECK_CLOSE(derivs[2]/*c*/, 3, 1e-14);
-    BOOST_CHECK_CLOSE(derivs[3]/*T*/,   42 * -1.39367393359350e-10, 1e-8);
-    BOOST_CHECK_CLOSE(derivs[4]/*S*/, 1e30 * -2.35966230954645e-10, 1e-8);
-    BOOST_CHECK_CLOSE(derivs[5]/*p*/, 1e30 *  4.58224843117053e-8 , 1e-8);
+    BOOST_CHECK_CLOSE(derivs[3]/*T*/,   42 * -1.39366806606821e-10, 1e-8);
+    BOOST_CHECK_CLOSE(derivs[4]/*S*/, 1e30 * -2.35971963482711e-10, 1e-8);
+    BOOST_CHECK_CLOSE(derivs[5]/*p*/, 1e30 *  4.58238131136642e-08 , 1e-8);
 
     BOOST_CHECK_CLOSE(
                 model.CalculateEquilibriumConcentration(Gas::XE),
-                9.61329873652310e-9,
+                9.60291390689642e-09,
                 1e-6
                 );
 
     BOOST_CHECK_CLOSE(
                 model.CalculateConcentration(Gas::XE),
-                (a + b + c + T) * 9.61329873652310e-9,
+                (a + b + c + T) * 9.60291390689642e-09,
                 1e-6
                 );
 
@@ -134,9 +134,9 @@ BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
     BOOST_CHECK_CLOSE(derivs[0]/*a*/, 0, 1e-14);
     BOOST_CHECK_CLOSE(derivs[1]/*b*/, 0, 1e-14);
     BOOST_CHECK_CLOSE(derivs[2]/*c*/, 0, 1e-14);
-    BOOST_CHECK_CLOSE(derivs[3]/*T*/, -2.90137245940027e-10, 1e-2);
-    BOOST_CHECK_CLOSE(derivs[4]/*S*/, -6.92150669107957e-11, 1e-2);
-    BOOST_CHECK_CLOSE(derivs[5]/*p*/,  9.74048724844832e-9 , 1e-2);
+    BOOST_CHECK_CLOSE(derivs[3]/*T*/, -2.89836210587424e-10, 1e-2);
+    BOOST_CHECK_CLOSE(derivs[4]/*S*/, -6.90227958127318e-11, 1e-2);
+    BOOST_CHECK_CLOSE(derivs[5]/*p*/,  9.73024428135358e-09 , 1e-2);
 
     derivs = model.CalculateDerivatives(Gas::XE);
 
@@ -144,9 +144,9 @@ BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
     BOOST_CHECK_CLOSE(derivs[0]/*a*/, 1, 1e-14);
     BOOST_CHECK_CLOSE(derivs[1]/*b*/, 2, 1e-14);
     BOOST_CHECK_CLOSE(derivs[2]/*c*/, 3, 1e-14);
-    BOOST_CHECK_CLOSE(derivs[3]/*T*/,   42 * -2.90137245940027e-10, 1e-2);
-    BOOST_CHECK_CLOSE(derivs[4]/*S*/, 1e30 * -6.92150669107957e-11, 1e-2);
-    BOOST_CHECK_CLOSE(derivs[5]/*p*/, 1e30 *  9.74048724844832e-9 , 1e-2);
+    BOOST_CHECK_CLOSE(derivs[3]/*T*/,   42 * -2.89836210587424e-10, 1e-2);
+    BOOST_CHECK_CLOSE(derivs[4]/*S*/, 1e30 * -6.90227958127318e-11, 1e-2);
+    BOOST_CHECK_CLOSE(derivs[5]/*p*/, 1e30 *  9.73024428135358e-09 , 1e-2);
 }
 
 BOOST_AUTO_TEST_CASE(SanityChecks)

--- a/src/core/testing/models/test_combinedmodel.cpp
+++ b/src/core/testing/models/test_combinedmodel.cpp
@@ -25,6 +25,7 @@
 
 #include "core/models/clevermethod.h"
 #include "core/models/weissmethod.h"
+#include "core/models/weissmethodfactory.h"
 #include "core/models/combinedmodel.h"
 
 #include "testmodel.h"
@@ -53,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ParameterNotFound)
 BOOST_AUTO_TEST_CASE(ConcentrationsAndDerivatives)
 {
     ModelFactory* factory(new TestFactory());
-    CEqMethodFactory* ceqmethod_factory(new TestCEqFactory());
+    CEqMethodFactory* ceqmethod_factory(new WeissMethodFactory()); // Use Weiss to test concentrations and derivatives
     CombinedModel model(factory, ceqmethod_factory);
 
     std::vector<int> indices;

--- a/src/core/testing/models/test_jenkinsmethod.cpp
+++ b/src/core/testing/models/test_jenkinsmethod.cpp
@@ -64,38 +64,51 @@ namespace
 BOOST_FIXTURE_TEST_SUITE(JenkinsMethod_tests, Fixture)
 
 BOOST_AUTO_TEST_CASE(CalculateConcentration)
-{
+{   
+    // Comparison with concentrations calculated with a Matlab skript
+    // using following physical properties:
+    // vpress (water vapor pressure) from Dickson2007/WagnerPruss2002/IAPWS-formulation1995
+    // Vmol (second virial) from Dymond and Smith 1980
+
+    T = 20;
+    S = 0;
+    p = 1;
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE),  4.544385343568145e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE),  1.878948951786380e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR),  3.137094392548901e-04, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR),  7.020546527474003e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE),  9.632920511893169e-09, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3), 6.18662079972421E-14,  1e-6);
 
     T = 0;
     S = 1;
     p = 2;
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 9.77748738846232e-08, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 4.48172212527456e-07, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 9.91230382674763e-04, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 2.47039748481394e-07, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 2.47039748481394e-07, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  1.328780665567e-13, 1e-6);
-
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE),  9.94671658952206e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE),  4.55243195998293e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR),  0.00100052397769738,  1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR),  2.49578519036359e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE),  3.89712229137032e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3), 1.35177926239257E-13,   1e-6);
 
     T = 10;
     S = .1;
     p = 1;
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.719475348066723e-08, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 2.042257015971631e-07, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 3.881118783853108e-04, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 9.154429843320715e-08, 1e-6);   // eigentlich neustes 9.155113959231087e-08
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 1.332573726696234e-08, 1e-6);   // eigentlich neustes 1.331172415306797e-08
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  6.315021552700E-14, 1e-6);    
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE),  4.71946504773741e-08,  1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE),  2.04235195092371e-07,  1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR),  3.880914456447179e-04, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR),  9.15504077615987e-08,  1e-6);   
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE),  1.331216894740430e-08, 1e-6);  
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3), 6.41944177163345E-14,  1e-6);    
 
     T = 20;
     S = 0;
     p = 1.01;
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.52241473452391e-08, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 1.86998524534805e-07, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 3.15103538968795e-04, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 7.03793929300997e-08, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 2.47039748481394e-07, 1e-6);
-    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  6.156710522179E-14, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE),  4.590903108209871e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE),  1.898182467103633e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR),  3.169206682237981e-04, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR),  7.092411060591457e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE),  9.731526130762817e-09, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3), 6.24994900552799E-14,  1e-6);
 }
 
 // BOOST_AUTO_TEST_CASE(CalculateDerivatives)

--- a/src/core/testing/models/test_jenkinsmethod.cpp
+++ b/src/core/testing/models/test_jenkinsmethod.cpp
@@ -1,0 +1,161 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+#include <Eigen/Core>
+
+#include <memory>
+
+#include <stdexcept>
+
+#include "core/models/parametermanager.h"
+#include "core/models/jenkinsmethod.h"
+#include <typeinfo>
+#include <iostream>
+
+namespace
+{
+    struct Fixture
+    {
+        Fixture() :
+            manager(new ParameterManager()),
+            method(manager),
+            accessor(method.GetParameterAccessor()),
+            vec(manager->GetParametersInOrder().size()),
+            T(vec[manager->GetParameterIndex("T")]),
+            S(vec[manager->GetParameterIndex("S")]),
+            p(vec[manager->GetParameterIndex("p")])
+        {
+            accessor->SetVectorReference(vec);
+        }
+
+        ~Fixture()
+        {
+        }
+
+        std::shared_ptr<ParameterManager> manager;
+        JenkinsMethod method;
+        std::shared_ptr<ParameterAccessor> accessor;
+        Eigen::VectorXd vec;
+
+        double& T;
+        double& S;
+        double& p;
+    };
+}
+
+BOOST_FIXTURE_TEST_SUITE(JenkinsMethod_tests, Fixture)
+
+BOOST_AUTO_TEST_CASE(CalculateConcentration)
+{
+
+    T = 0;
+    S = 1;
+    p = 2;
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 9.77748738846232e-08, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 4.48172212527456e-07, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 9.91230382674763e-04, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 2.47039748481394e-07, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 2.47039748481394e-07, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  1.328780665567e-13, 1e-6);
+
+
+    T = 10;
+    S = .1;
+    p = 1;
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.719475348066723e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 2.042257015971631e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 3.881118783853108e-04, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 9.154429843320715e-08, 1e-6);   // eigentlich neustes 9.155113959231087e-08
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 1.332573726696234e-08, 1e-6);   // eigentlich neustes 1.331172415306797e-08
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  6.315021552700E-14, 1e-6);    
+
+    T = 20;
+    S = 0;
+    p = 1.01;
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.52241473452391e-08, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 1.86998524534805e-07, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 3.15103538968795e-04, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 7.03793929300997e-08, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::XE), 2.47039748481394e-07, 1e-6);
+    // BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  6.156710522179E-14, 1e-6);
+}
+
+// BOOST_AUTO_TEST_CASE(CalculateDerivatives)
+// {
+//     std::shared_ptr<DerivativeCollector> dcol(method.GetDerivativeCollector());
+//     Eigen::RowVectorXd derivatives(5);
+
+//     std::vector<int> indices;
+//     indices.push_back(17);
+//     indices.push_back(manager->GetParameterIndex("S"));
+//     indices.push_back(manager->GetParameterIndex("p"));
+//     indices.push_back(42);
+//     indices.push_back(manager->GetParameterIndex("T"));
+
+//     dcol->SetDerivativesAndResultsVector(derivatives, indices);
+
+//     T = 20;
+//     S = 0;
+//     p = 1.01;
+//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::HE));
+
+//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  4.58224843117053e-8 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.39367393359350e-10, 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.35966230954645e-10, 1e-8);
+//     std::cout<< derivatives[2/*p*/] << typeid(derivatives[2/*p*/]).name()<<std::endl;
+//     T = 23;
+//     S = .001;
+//     p = .99;
+//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::NE));
+
+//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.86125977680312e-7 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.31571642279490e-9 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -9.95245051655393e-10, 1e-8);
+
+//     T = 0;
+//     S = 10;
+//     p = 10;
+//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::AR));
+
+//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  4.63811930704642e-4 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.24682052351936e-4 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -3.57122182199191e-5 , 1e-8);
+
+//     T = 1;
+//     S = 2;
+//     p = 3;
+//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::KR));
+
+//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.18975732781123e-7 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.15742902312524e-8 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.79577411713379e-9 , 1e-8);
+
+//     T = 1;
+//     S = 2;
+//     p = 3;
+//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::XE));
+
+//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.18975732781123e-7 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.15742902312524e-8 , 1e-8);
+//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.79577411713379e-9 , 1e-8);
+// }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/core/testing/models/test_jenkinsmethod.cpp
+++ b/src/core/testing/models/test_jenkinsmethod.cpp
@@ -111,64 +111,81 @@ BOOST_AUTO_TEST_CASE(CalculateConcentration)
     BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3), 6.24994900552799E-14,  1e-6);
 }
 
-// BOOST_AUTO_TEST_CASE(CalculateDerivatives)
-// {
-//     std::shared_ptr<DerivativeCollector> dcol(method.GetDerivativeCollector());
-//     Eigen::RowVectorXd derivatives(5);
+BOOST_AUTO_TEST_CASE(CalculateDerivatives)
+{
+    std::shared_ptr<DerivativeCollector> dcol(method.GetDerivativeCollector());
+    Eigen::RowVectorXd derivatives(5);
 
-//     std::vector<int> indices;
-//     indices.push_back(17);
-//     indices.push_back(manager->GetParameterIndex("S"));
-//     indices.push_back(manager->GetParameterIndex("p"));
-//     indices.push_back(42);
-//     indices.push_back(manager->GetParameterIndex("T"));
+    std::vector<int> indices;
+    indices.push_back(17);
+    indices.push_back(manager->GetParameterIndex("S"));
+    indices.push_back(manager->GetParameterIndex("p"));
+    indices.push_back(42);
+    indices.push_back(manager->GetParameterIndex("T"));
 
-//     dcol->SetDerivativesAndResultsVector(derivatives, indices);
+    dcol->SetDerivativesAndResultsVector(derivatives, indices);
 
-//     T = 20;
-//     S = 0;
-//     p = 1.01;
-//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::HE));
 
-//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  4.58224843117053e-8 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.39367393359350e-10, 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.35966230954645e-10, 1e-8);
-//     std::cout<< derivatives[2/*p*/] << typeid(derivatives[2/*p*/]).name()<<std::endl;
-//     T = 23;
-//     S = .001;
-//     p = .99;
-//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::NE));
+    p = 1.01;
+    T = 20;
+    S = 0;
+    double c_; double c2_; double c4_; double c1_; double b;
+    c_ = method.CalculateConcentration(accessor, Gas::HE); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::HE); p = 1.01;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::HE); T = 20;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::HE); S = 0;
+    BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::HE));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.86125977680312e-7 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.31571642279490e-9 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -9.95245051655393e-10, 1e-8);
+    p = .99;
+    T = 23;
+    S = .001;
+    c_ = method.CalculateConcentration(accessor, Gas::NE); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::NE); p = .99;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::NE); T = 23;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::NE); S = .001;
+    BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::NE));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-//     T = 0;
-//     S = 10;
-//     p = 10;
-//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::AR));
+    p = 10;
+    T = 0;
+    S = 10;
+    c_ = method.CalculateConcentration(accessor, Gas::AR); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::AR); p = 10;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::AR); T = 0;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::AR); S = 10;
+    BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::AR));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  4.63811930704642e-4 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.24682052351936e-4 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -3.57122182199191e-5 , 1e-8);
+    p = 3;
+    T = 1;
+    S = 2;
+    c_ = method.CalculateConcentration(accessor, Gas::KR); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::KR); p = 3;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::KR); T = 1;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::KR); S = 2;
+    BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::KR));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-//     T = 1;
-//     S = 2;
-//     p = 3;
-//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::KR));
-
-//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.18975732781123e-7 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.15742902312524e-8 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.79577411713379e-9 , 1e-8);
-
-//     T = 1;
-//     S = 2;
-//     p = 3;
-//     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::XE));
-
-//     BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.18975732781123e-7 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.15742902312524e-8 , 1e-8);
-//     BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.79577411713379e-9 , 1e-8);
-// }
+    p = 3;
+    T = 1;
+    S = 2;
+    c_ = method.CalculateConcentration(accessor, Gas::XE); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::XE); p = 3;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::XE); T = 1;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::XE); S = 2;
+    BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::XE));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/core/testing/models/test_physicalproperties.cpp
+++ b/src/core/testing/models/test_physicalproperties.cpp
@@ -23,43 +23,43 @@
 
 BOOST_AUTO_TEST_SUITE(PhysicalProperties_tests)
 
-BOOST_AUTO_TEST_CASE(CalcSaturationVaporPressure)
+BOOST_AUTO_TEST_CASE(CalcSaturationVaporPressure_Gill)
 {
     BOOST_CHECK_CLOSE(
-                PhysicalProperties::CalcSaturationVaporPressure(0),
+                PhysicalProperties::CalcSaturationVaporPressure_Gill(0),
                 6.0281407994095e-3,
                 1e-6
                 );
 
     BOOST_CHECK_CLOSE(
-                PhysicalProperties::CalcSaturationVaporPressure(10),
+                PhysicalProperties::CalcSaturationVaporPressure_Gill(10),
                 1.2106738021575e-2,
                 1e-6
                 );
 
     BOOST_CHECK_CLOSE(
-                PhysicalProperties::CalcSaturationVaporPressure(20),
+                PhysicalProperties::CalcSaturationVaporPressure_Gill(20),
                 2.3057715561949e-2,
                 1e-6
                 );
 }
 
-BOOST_AUTO_TEST_CASE(CalcSaturationVaporPressureDerivative)
+BOOST_AUTO_TEST_CASE(CalcSaturationVaporPressureDerivative_Gill)
 {
     BOOST_CHECK_CLOSE(
-                PhysicalProperties::CalcSaturationVaporPressureDerivative(0),
+                PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(0),
                 4.37679406606328e-04,
                 1e-2
                 );
 
     BOOST_CHECK_CLOSE(
-                PhysicalProperties::CalcSaturationVaporPressureDerivative(10),
+                PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(10),
                 8.10861794375839e-04,
                 1e-2
                 );
 
     BOOST_CHECK_CLOSE(
-                PhysicalProperties::CalcSaturationVaporPressureDerivative(20),
+                PhysicalProperties::CalcSaturationVaporPressureDerivative_Gill(20),
                 1.42896111610114e-03,
                 1e-2
                 );

--- a/src/core/testing/models/test_weissmethod.cpp
+++ b/src/core/testing/models/test_weissmethod.cpp
@@ -63,7 +63,7 @@ BOOST_FIXTURE_TEST_SUITE(WeissMethod_tests, Fixture)
 
 BOOST_AUTO_TEST_CASE(CalculateConcentration)
 {
-    BOOST_CHECK_THROW(method.CalculateConcentration(accessor, Gas::XE), std::runtime_error);
+    BOOST_CHECK_THROW(method.CalculateConcentration(accessor, Gas::XE), std::runtime_error); // prüfen ob Xe bei Weiss rausgenommen
 
     T = 0;
     S = 1;

--- a/src/core/testing/models/test_weissmethod.cpp
+++ b/src/core/testing/models/test_weissmethod.cpp
@@ -68,30 +68,29 @@ BOOST_AUTO_TEST_CASE(CalculateConcentration)
     T = 0;
     S = 1;
     p = 2;
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 9.77748738846232e-08, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 4.48172212527456e-07, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 9.91230382674763e-04, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 2.47039748481394e-07, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  1.328780665567e-13, 1e-6);
-
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 9.7774918691313e-08,  1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 4.48172417908578e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 0.000991230836919811, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 2.47039861690779e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),1.32878127449914e-13, 1e-6);
 
     T = 10;
     S = .1;
     p = 1;
     BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.64269706836073e-08, 1e-6);
     BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 2.01619787901304e-07, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 3.85849249750526e-04, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 0.000385849249750526, 1e-6);
     BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 9.09654355930234e-08, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  6.315021552700E-14, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),6.3150215527e-14,     1e-6);
 
     T = 20;
     S = 0;
     p = 1.01;
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.52241473452391e-08, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 1.86998524534805e-07, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 3.15103538968795e-04, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 7.03793929300997e-08, 1e-6);
-    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),  6.156710522179E-14, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE), 4.52241606332239e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::NE), 1.86998579479645e-07, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::AR), 0.00031510363155409,  1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::KR), 7.03794136093243e-08, 1e-6);
+    BOOST_CHECK_CLOSE(method.CalculateConcentration(accessor, Gas::HE3),6.15671233117443e-14, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(CalculateDerivatives)
@@ -110,41 +109,54 @@ BOOST_AUTO_TEST_CASE(CalculateDerivatives)
 
     BOOST_CHECK_THROW(method.CalculateDerivatives(accessor, dcol, Gas::XE), std::runtime_error);
 
+    p = 1.01;
     T = 20;
     S = 0;
-    p = 1.01;
+    double c_; double c2_; double c4_; double c1_; double b;
+    c_ = method.CalculateConcentration(accessor, Gas::HE); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::HE);    p = 1.01;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::HE);    T = 20;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::HE);    S = 0;
     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::HE));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-2);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-    BOOST_CHECK_CLOSE(derivatives[2/*p*/],  4.58224843117053e-8 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.39367393359350e-10, 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.35966230954645e-10, 1e-8);
-
+    p = .99;
     T = 23;
     S = .001;
-    p = .99;
+    c_ = method.CalculateConcentration(accessor, Gas::NE); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::NE); p = .99;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::NE); T = 23;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::NE); S = .001;
     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::NE));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-    BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.86125977680312e-7 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.31571642279490e-9 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[1/*S*/], -9.95245051655393e-10, 1e-8);
-
+    p = 10;
     T = 0;
     S = 10;
-    p = 10;
+    c_ = method.CalculateConcentration(accessor, Gas::AR); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::AR);  p = 10;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::AR);  T = 0;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::AR);  S = 10;
     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::AR));
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 
-    BOOST_CHECK_CLOSE(derivatives[2/*p*/],  4.63811930704642e-4 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.24682052351936e-4 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[1/*S*/], -3.57122182199191e-5 , 1e-8);
-
+    p = 3;
     T = 1;
     S = 2;
-    p = 3;
+    c_ = method.CalculateConcentration(accessor, Gas::KR); b = 1E-6;
+    p = p + b; c2_ = method.CalculateConcentration(accessor, Gas::KR); p = 3;
+    T = T + b; c4_ = method.CalculateConcentration(accessor, Gas::KR); T = 1;
+    S = S + b; c1_ = method.CalculateConcentration(accessor, Gas::KR); S = 2;
     BOOST_REQUIRE_NO_THROW(method.CalculateDerivatives(accessor, dcol, Gas::KR));
-
-    BOOST_CHECK_CLOSE(derivatives[2/*p*/],  1.18975732781123e-7 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[4/*T*/], -1.15742902312524e-8 , 1e-8);
-    BOOST_CHECK_CLOSE(derivatives[1/*S*/], -2.79577411713379e-9 , 1e-8);
+    BOOST_CHECK_CLOSE(derivatives[2/*p*/], (c2_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[4/*T*/], (c4_-c_)/b, 1e-3);
+    BOOST_CHECK_CLOSE(derivatives[1/*S*/], (c1_-c_)/b, 1e-3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/core/testing/models/testceqmethod.h
+++ b/src/core/testing/models/testceqmethod.h
@@ -1,0 +1,133 @@
+// Copyright © 2014 Michael Jung
+// 
+// This file is part of Panga.
+// 
+// Panga is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Panga is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Panga.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef TESTCEQMETHOD_H
+#define TESTCEQMETHOD_H
+
+#include "core/models/ceqcalculationmethod.h"
+#include "core/models/ceqmethodfactory.h"
+#include "core/models/parametermanager.h"
+
+#define NOBLE_PARAMETER_COUNT 3
+#define NOBLE_PARAMETER_NAMES (p, S, T)
+#define NOBLE_CLASS_PREFIX TestCEq
+#define NOBLE_IS_CEQ_CALCULATION_METHOD
+#include "core/models/generatehelperclasses.h"
+
+class TestCEqMethod : public CEqCalculationMethod
+{
+public:
+    TestCEqMethod(std::shared_ptr<ParameterManager> manager) :
+        pi_(manager->RegisterParameter("p", "atm")),
+        Si_(manager->RegisterParameter("S", "g/kg")),
+        Ti_(manager->RegisterParameter("T", "°C"))
+    {
+    }
+
+    std::shared_ptr<ParameterAccessor> GetParameterAccessor() const
+    {
+        return std::make_shared<TestCEqParameterAccessor>(pi_, Si_, Ti_);
+    }
+
+    std::shared_ptr<DerivativeCollector> GetDerivativeCollector() const
+    {
+        return std::make_shared<TestCEqDerivativeCollector>(pi_, Si_, Ti_);
+    }
+    double CalculateConcentration(
+        std::shared_ptr<ParameterAccessor> parameters,
+        GasType gas
+        ) const
+    {
+        std::shared_ptr<TestCEqParameterAccessor> x(
+                    std::dynamic_pointer_cast<TestCEqParameterAccessor>(parameters));
+        return (x->p() + x->S() + x->T());
+    }
+
+    void CalculateDerivatives(
+        std::shared_ptr<ParameterAccessor> parameters,
+        std::shared_ptr<DerivativeCollector> derivatives,
+        GasType gas
+        ) const
+    {
+        std::shared_ptr<TestCEqParameterAccessor> x(
+                    std::dynamic_pointer_cast<TestCEqParameterAccessor>(parameters));
+        std::shared_ptr<TestCEqDerivativeCollector> y(
+                    std::dynamic_pointer_cast<TestCEqDerivativeCollector>(derivatives));
+
+        const std::vector<std::pair<TestCEq::Parameter, double*> >& infos = y->GetDerivativeInformation();
+
+        for (std::vector<std::pair<TestCEq::Parameter, double*> >::const_iterator it = infos.begin();
+             it != infos.end();
+             ++it)
+        {
+            switch (it->first)
+            {
+            case TestCEq::p:
+                *it->second = 1.;
+                break;
+
+            case TestCEq::S:
+                *it->second = 2.;
+                break;
+
+            case TestCEq::T:
+                *it->second *= 42;
+                break;
+
+            case TestCEq::OTHER:
+                *it->second *= 1e30;
+                break;
+
+            default:
+                *it->second = 0;
+                break;
+            }
+        }
+    }
+
+    std::string GetCEqMethodName() const
+    {
+        return "TestCEq";
+    }
+
+private:
+    const unsigned pi_;
+    const unsigned Si_;
+    const unsigned Ti_;
+};
+
+class TestCEqFactory : public CEqMethodFactory
+{
+public:
+    ~TestCEqFactory() {}
+
+    std::shared_ptr<CEqCalculationMethod> CreateCEqMethod(
+        std::shared_ptr<ParameterManager> manager
+        ) const
+
+    {
+        return std::make_shared<TestCEqMethod>(manager);
+    }
+
+    std::string GetCEqMethodName() const
+    {
+        return "TestCEq";
+    }
+};
+
+#endif // TESTCEQMETHOD_H

--- a/src/gui/concentrationsmodel.cpp
+++ b/src/gui/concentrationsmodel.cpp
@@ -123,7 +123,7 @@ void ConcentrationsModel::LoadSamplesIntoModel(QTextStream& stream)
     if (samples.empty())
     {
         QMessageBox::warning(nullptr, APPLICATION_NAME,
-                             "Error: Invalid input format.");
+                             "Error: Invalid input format."); //WIP
         return;
     }
     if (ContainsDuplicateSampleNames(samples)) 
@@ -151,7 +151,7 @@ void ConcentrationsModel::LoadSamplesIntoModel(QTextStream& stream)
 Sample ConcentrationsModel::CreateSampleFromLine(const QString& line) const
 {
     QStringList strings;
-    if (!((strings = line.split(',' )).size() == 11 ||
+    if (!((strings = line.split(',' )).size() == 11 || //WIP-ev1
           (strings = line.split('\t')).size() == 11))
         throw std::invalid_argument("A line must consist of the sample name "
                                     "and the following concentrations, all "
@@ -162,7 +162,7 @@ Sample ConcentrationsModel::CreateSampleFromLine(const QString& line) const
     std::string sample_name = strings.takeFirst().toStdString();
     SampleConcentrations concentrations;
     
-    for (unsigned i = 0; i < 5; ++i)
+    for (unsigned i = 0; i < 5; ++i) //WIP-ev1
     {
         bool value_ok = true;
         bool error_ok = true;

--- a/src/gui/concentrationsmodel.cpp
+++ b/src/gui/concentrationsmodel.cpp
@@ -123,7 +123,7 @@ void ConcentrationsModel::LoadSamplesIntoModel(QTextStream& stream)
     if (samples.empty())
     {
         QMessageBox::warning(nullptr, APPLICATION_NAME,
-                             "Error: Invalid input format."); //WIP
+                             "Error: Invalid input format.");
         return;
     }
     if (ContainsDuplicateSampleNames(samples)) 
@@ -151,7 +151,7 @@ void ConcentrationsModel::LoadSamplesIntoModel(QTextStream& stream)
 Sample ConcentrationsModel::CreateSampleFromLine(const QString& line) const
 {
     QStringList strings;
-    if (!((strings = line.split(',' )).size() == 11 || //WIP-ev1
+    if (!((strings = line.split(',' )).size() == 11 ||
           (strings = line.split('\t')).size() == 11))
         throw std::invalid_argument("A line must consist of the sample name "
                                     "and the following concentrations, all "
@@ -162,7 +162,7 @@ Sample ConcentrationsModel::CreateSampleFromLine(const QString& line) const
     std::string sample_name = strings.takeFirst().toStdString();
     SampleConcentrations concentrations;
     
-    for (unsigned i = 0; i < 5; ++i) //WIP-ev1
+    for (unsigned i = 0; i < 5; ++i)
     {
         bool value_ok = true;
         bool error_ok = true;

--- a/src/gui/fitsetup.cpp
+++ b/src/gui/fitsetup.cpp
@@ -374,8 +374,19 @@ void FitSetup::SetModel(QString name)
         ResetModel();
         return;
     }
-    
-    model_ = CombinedModelFactory(factory).CreateModel();
+
+    ModelFactory* ceqmethod_factory;
+    try
+    {
+        factory = ModelManager::Get().GetModelFactory(name.toStdString());
+    }
+    catch (ModelManager::ModelNotFoundError)
+    {
+        ResetModel();
+        return;
+    }    
+
+    model_ = CombinedModelFactory(factory, ceqmethod_factory).CreateModel();
     InitializeParameters();
     emit ModelChanged();
 }

--- a/src/gui/fitsetup.cpp
+++ b/src/gui/fitsetup.cpp
@@ -382,9 +382,9 @@ void FitSetup::SetModel(QString name, QString ceqmethodname)
     CEqMethodFactory* ceqmethod_factory;
     try
     {
-        ceqmethod_factory = CEqMethodManager::Get().GetCEqMethodFactory(ceqmethodname.toStdString()); //WIP Test
+        ceqmethod_factory = CEqMethodManager::Get().GetCEqMethodFactory(ceqmethodname.toStdString());
     }
-    catch (CEqMethodManager::CEqMethodNotFoundError) //WIP noch anpassen?
+    catch (CEqMethodManager::CEqMethodNotFoundError)
     {
         ResetModel();
         return;

--- a/src/gui/fitsetup.cpp
+++ b/src/gui/fitsetup.cpp
@@ -28,7 +28,6 @@
 #include "core/fitting/defaultfitter.h"
 #include "core/models/modelmanager.h"
 #include "core/models/ceqmethodmanager.h"
-#include "core/models/weissmethodfactory.h" //WIP: Vorübergehend
 
 #include "chi2explorer.h"
 #include "commons.h"
@@ -68,7 +67,7 @@ FitSetup::FitSetup(QWidget* parent) :
         std::string first_ceqmethod = ceqmethods.empty() ?
                                   std::string("") :
                                   ceqmethods.front();              
-        SetModel(QString::fromStdString(first_model), QString::fromStdString(first_ceqmethod)); //WIP: SETMODEL??
+        SetModel(QString::fromStdString(first_model), QString::fromStdString(first_ceqmethod));
     }
     
     ConnectSignalsAndSlots();
@@ -362,9 +361,9 @@ void FitSetup::ResetModel()
     emit ModelChanged();
 }
 
-void FitSetup::SetModel(QString name, QString ceqmethodname) //WIP: SETMODEL
+void FitSetup::SetModel(QString name, QString ceqmethodname)
 {
-    if (name.isEmpty() || ceqmethodname.isEmpty()) //WIP: Testen ob es Unterschied macht ob Jenkins verwendet wird!
+    if (name.isEmpty() || ceqmethodname.isEmpty())
     {
         ResetModel();
         return;
@@ -385,23 +384,11 @@ void FitSetup::SetModel(QString name, QString ceqmethodname) //WIP: SETMODEL
     {
         ceqmethod_factory = CEqMethodManager::Get().GetCEqMethodFactory(ceqmethodname.toStdString()); //WIP Test
     }
-    catch (CEqMethodManager::CEqMethodNotFoundError) //WIP noch anpassen!!! Bedeutung
+    catch (CEqMethodManager::CEqMethodNotFoundError) //WIP noch anpassen?
     {
         ResetModel();
         return;
-    }
-    // std::string Test = ceqmethodname.toStdString(); 
-    // std::cout<<Test;
-    // CEqMethodFactory* ceqmethod_factory2;
-    // try
-    // {
-    //     ceqmethod_factory2 = CEqMethodManager::Get().GetCEqMethodFactory(ceqmethodname.toStdString()); //WIP: MACHT PROBLEME 
-    // }                                                                                                  //WIP: vllt schon in Fkt SetModel sobald es gebraucht wird
-    // catch (CEqMethodManager::CEqMethodNotFoundError)
-    // {
-    //     ResetModel();
-    //     return;
-    // }
+    }    
 
     combined_model_ = CombinedModelFactory(factory, ceqmethod_factory).CreateModel();
     InitializeParameters();

--- a/src/gui/fitsetup.h
+++ b/src/gui/fitsetup.h
@@ -138,7 +138,7 @@ private:
     
     QString name_;
 
-    std::shared_ptr<CombinedModel> model_;
+    std::shared_ptr<CombinedModel> combined_model_;
     
     static const QString DEFAULT_NAME;
     
@@ -157,7 +157,7 @@ private:
 template<class Archive>
 void FitSetup::save(Archive& ar, const unsigned version) const
 {
-    std::string model = model_->GetExcessAirModelName();
+    std::string model = combined_model_->GetExcessAirModelName();
     ar << model;
     bool constraints_applied = AreConstraintsApplied();
     ar << constraints_applied;

--- a/src/gui/fitsetup.h
+++ b/src/gui/fitsetup.h
@@ -75,8 +75,9 @@ public:
                                             bool individually_configured);
 
     bool HasModel() const;
-    void SetModel(QString name);
+    void SetModel(QString name, QString ceqmethodname);
     QString GetModelName() const;
+    QString GetCEqMethodName() const;
     QString GetName() const;
     bool AreConstraintsApplied() const;
     
@@ -159,6 +160,9 @@ void FitSetup::save(Archive& ar, const unsigned version) const
 {
     std::string model = combined_model_->GetExcessAirModelName();
     ar << model;
+    std::string ceqmethod = combined_model_->GetCEqMethodName();
+    ar << ceqmethod;
+
     bool constraints_applied = AreConstraintsApplied();
     ar << constraints_applied;
     
@@ -177,7 +181,11 @@ void FitSetup::load(Archive& ar, const unsigned version)
 {              
     std::string model;
     ar >> model;
-    SetModel(QString::fromStdString(model));
+    std::string ceqmethod;
+    ar >> ceqmethod;
+    //WIP: Öffnen gespeicherter Ergebnisse aus voriger Version möglich machen
+
+    SetModel(QString::fromStdString(model), QString::fromStdString(ceqmethod)); 
     
     if (version >= 2)
     {

--- a/src/gui/fitsetup.h
+++ b/src/gui/fitsetup.h
@@ -183,7 +183,7 @@ void FitSetup::load(Archive& ar, const unsigned version)
     ar >> model;
     std::string ceqmethod;
     ar >> ceqmethod;
-    //WIP: Öffnen gespeicherter Ergebnisse aus voriger Version möglich machen
+    //(todo): Öffnen gespeicherter Ergebnisse aus voriger Version möglich machen
 
     SetModel(QString::fromStdString(model), QString::fromStdString(ceqmethod)); 
     

--- a/src/gui/fitsetupwidget.cpp
+++ b/src/gui/fitsetupwidget.cpp
@@ -23,6 +23,7 @@
 #include <QPushButton>
 #include <QScrollBar>
 #include <QVBoxLayout>
+#include <QAction>
 
 #include <algorithm>
 

--- a/src/gui/fitsetupwidget.cpp
+++ b/src/gui/fitsetupwidget.cpp
@@ -97,12 +97,12 @@ void FitSetupWidget::SetFitSetup(FitSetup* fit_setup)
     LinkModelsAndViews();
 
     UpdateGasesInUse();
-    int model_index = ui->model_combo_box->findText(fit_setup_->GetModelName()); //WIP: Wofür ist dieser Teil gut?
+    int model_index = ui->model_combo_box->findText(fit_setup_->GetModelName()); 
     {
         SignalBlocker blocker(ui->model_combo_box);
         ui->model_combo_box->setCurrentIndex(model_index);
     }
-    int ceqmethod_index = ui->solubility_combo_box->findText(fit_setup_->GetCEqMethodName()); //WIP: Wofür ist dieser Teil gut?
+    int ceqmethod_index = ui->solubility_combo_box->findText(fit_setup_->GetCEqMethodName()); 
     {
         SignalBlocker blocker(ui->solubility_combo_box);
         ui->solubility_combo_box->setCurrentIndex(ceqmethod_index);
@@ -205,12 +205,12 @@ void FitSetupWidget::InitializeModelBox()
             this, SLOT(SetActiveModel()));
 }
 
-void FitSetupWidget::InitializeSolubilityBox() //WIP: Mehr anzupassen?
+void FitSetupWidget::InitializeSolubilityBox() //(note): Mehr anzupassen?
 {
     std::vector<std::string> available_models =
-            CEqMethodManager::Get().GetAvailableCEqMethods(); //WIP: Gleiches Problem wie davor!
+            CEqMethodManager::Get().GetAvailableCEqMethods(); //(note): Gleiches Problem wie davor!
 
-    if (available_models.empty()) //WIP: anpassen?
+    if (available_models.empty()) //(note): anpassen?
     {
         //! \todo Irgendwie sicherstellen, dass die Fitknöpfe auch deaktiviert sind.
 //         ui->standard_fit_button->setEnabled(false);
@@ -307,7 +307,7 @@ void FitSetupWidget::EmitNameChanged(QString name)
 
 void FitSetupWidget::SetActiveModel()
 {
-    fit_setup_->SetModel(ui->model_combo_box->currentText(), ui->solubility_combo_box->currentText()); //WIP: SETMODEL
+    fit_setup_->SetModel(ui->model_combo_box->currentText(), ui->solubility_combo_box->currentText());
 }
 
 void FitSetupWidget::UpdateParameters()

--- a/src/gui/fitsetupwidget.cpp
+++ b/src/gui/fitsetupwidget.cpp
@@ -210,7 +210,7 @@ void FitSetupWidget::InitializeSolubilityBox() //WIP: Mehr anzupassen?
     std::vector<std::string> available_models =
             CEqMethodManager::Get().GetAvailableCEqMethods(); //WIP: Gleiches Problem wie davor!
 
-    if (available_models.empty()) //WIP: irgendwas anpassen??
+    if (available_models.empty()) //WIP: anpassen?
     {
         //! \todo Irgendwie sicherstellen, dass die Fitknöpfe auch deaktiviert sind.
 //         ui->standard_fit_button->setEnabled(false);

--- a/src/gui/fitsetupwidget.h
+++ b/src/gui/fitsetupwidget.h
@@ -59,6 +59,7 @@ protected:
 private:
     void LinkModelsAndViews();
     void InitializeModelBox();
+    void InitializeSolubilityBox();
     void SetupNobleGasCheckBoxes();
     
     //! Entfernt und zerstört alle Widgets des Layouts sowie das Layout selbst.

--- a/src/gui/fitsetupwidget.ui
+++ b/src/gui/fitsetupwidget.ui
@@ -127,18 +127,18 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
            </layout>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="model_label">
+        <item row="2" column="0">
+          <widget class="QLabel" name="solubility_label">
            <property name="text">
-            <string>Mo&amp;del:</string>
+            <string>Solu&amp;bilities:</string>
            </property>
            <property name="buddy">
-            <cstring>model_combo_box</cstring>
+            <cstring>solubility_combo_box</cstring>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QComboBox" name="model_combo_box">
+          <widget class="QComboBox" name="solubility_combo_box">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -148,13 +148,33 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
           </widget>
          </item>
          <item row="3" column="0">
+          <widget class="QLabel" name="model_label">
+           <property name="text">
+            <string>Mo&amp;del:</string>
+           </property>
+           <property name="buddy">
+            <cstring>model_combo_box</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QComboBox" name="model_combo_box">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
           <widget class="QLabel" name="parameters_to_fit_label">
            <property name="text">
             <string>Parameters to fit:</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <widget class="QGroupBox" name="parameters_group_box">
            <property name="title">
             <string/>
@@ -162,14 +182,14 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
            <layout class="QVBoxLayout" name="verticalLayout_3"/>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="initials_label">
            <property name="text">
             <string>Parameter initials:</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="5" column="1">
           <widget class="QGroupBox" name="initials_group_box">
            <property name="title">
             <string/>
@@ -177,14 +197,14 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
            <layout class="QGridLayout" name="gridLayout"/>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="values_label">
            <property name="text">
             <string>Parameter values:</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="6" column="1">
           <widget class="QGroupBox" name="values_group_box">
            <property name="title">
             <string/>
@@ -192,7 +212,7 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
            <layout class="QGridLayout" name="gridLayout_2"/>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="8" column="0">
           <widget class="QLabel" name="n_monte_carlos_label">
            <property name="text">
             <string>Monte &amp;Carlos:</string>
@@ -202,7 +222,7 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="8" column="1">
           <widget class="QSpinBox" name="n_monte_carlos_spin_box">
            <property name="maximum">
             <number>99999999</number>
@@ -222,14 +242,14 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="7" column="1">
           <widget class="QCheckBox" name="constrained_fit_checkbox">
            <property name="text">
             <string/>
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="constrained_fit_label">
            <property name="text">
             <string>Constrained Fit:</string>
@@ -329,6 +349,7 @@ along with Panga.  If not, see <http://www.gnu.org/licenses/>.
   <tabstop>ar_check_box</tabstop>
   <tabstop>kr_check_box</tabstop>
   <tabstop>xe_check_box</tabstop>
+  <tabstop>solubility_combo_box</tabstop>
   <tabstop>model_combo_box</tabstop>
   <tabstop>n_monte_carlos_spin_box</tabstop>
   <tabstop>concentrations_view</tabstop>

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -23,9 +23,11 @@
 #include <iostream>
 
 #include "mainwindow.h"
+#include "../core/testing/models/manualtest_models.cpp"
 
 int main(int argc, char* argv[])
-{
+{   
+    manualtesting::test();
     QApplication app(argc, argv);
     std::locale::global(std::locale::classic());
     QLocale::setDefault(QLocale::c());

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -23,11 +23,11 @@
 #include <iostream>
 
 #include "mainwindow.h"
-#include "../core/testing/models/manualtest_models.cpp"
+// #include "../core/testing/models/manualtest_models.cpp"
 
 int main(int argc, char* argv[])
 {   
-    manualtesting::test();
+    // manualtesting::test();
     QApplication app(argc, argv);
     std::locale::global(std::locale::classic());
     QLocale::setDefault(QLocale::c());

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -23,11 +23,11 @@
 #include <iostream>
 
 #include "mainwindow.h"
-// #include "../core/testing/models/manualtest_models.cpp"
+#include "../core/testing/models/manualtest_models.cpp"
 
 int main(int argc, char* argv[])
 {   
-    // manualtesting::test();
+    manualtesting::test();
     QApplication app(argc, argv);
     std::locale::global(std::locale::classic());
     QLocale::setDefault(QLocale::c());

--- a/src/gui/resultsmodel.cpp
+++ b/src/gui/resultsmodel.cpp
@@ -131,7 +131,7 @@ const QList<ExtendedColumnType> ResultsModel::GetDoubleColumnTypes() const
     return available_column_types;
 }
 
-QVariant ResultsModel::GetElement( //WIP: Für einen Column Type, welche werden alle abgefragt?
+QVariant ResultsModel::GetElement( //(note) Für einen Column Type, welche werden alle abgefragt?
         const FitResults& results,
         const ExtendedColumnType& column_type) const
 {
@@ -197,7 +197,7 @@ QVariant ResultsModel::GetElement( //WIP: Für einen Column Type, welche werden 
                     )
                 );
             case ColumnType::RAD_HE3:
-                return 0.00000002*( //WIP: in physical properties!
+                return 0.00000002*( //(todo): in physical properties!
                         results.measured_concentrations.at(0).at(                    
                         static_cast<GasType>(0)).value
                         - results.model_concentrations.at(0).at(
@@ -327,7 +327,7 @@ double ResultsModel::GetResidualForGas(const FitResults& results,
     GasType gas = GetGasFromIndex(gas_index);
     assert(results.residuals.size() == unsigned(results.residual_gases.size()));
     for (unsigned i = 0; i < results.residuals.size(); ++i)
-        if (results.residual_gases[i] == gas) //WIP: Wofür brauche ich die Prüfung und brauche ich sie auch für DNe?
+        if (results.residual_gases[i] == gas) //(note) Reihenfolge residuals entspricht nicht unbedingt gasen
             return results.residuals[i];
     return std::numeric_limits<double>::quiet_NaN();
 }
@@ -335,7 +335,6 @@ double ResultsModel::GetResidualForGas(const FitResults& results,
 
 double ResultsModel::GetDeltaNeon(const FitResults& results) const
 {
-    //WIP: Prüfen ob es Neon gibt?
     return 
         (
             results.measured_concentrations.at(0).at(static_cast<GasType>(1)).value

--- a/src/gui/resultsmodel.cpp
+++ b/src/gui/resultsmodel.cpp
@@ -99,15 +99,15 @@ const QList<ExtendedColumnType> ResultsModel::GetAvailableColumnTypes() const //
         cols.push_back({ColumnType::MODEL_CONCENTRATION_ERROR, i});
     }
 
-    for (unsigned i = 0; i < 5; ++i)
+    for (unsigned i = 0; i < 5; ++i) //WIPev1
     {
         cols.push_back({ColumnType::MEASURED_CONCENTRATION,       i});
         cols.push_back({ColumnType::MEASURED_CONCENTRATION_ERROR, i});
     }
 
     cols.push_back({ColumnType::CHI, 0});
-    cols.push_back({ColumnType::DELTA_NEON,         1}); //WIP: 1 wird nicht verwendet
-    cols.push_back({ColumnType::DELTA_NEON_ERROR,   1});
+    cols.push_back({ColumnType::DELTA_NEON,         0});
+    cols.push_back({ColumnType::DELTA_NEON_ERROR,   0});
     cols.push_back({ColumnType::RAD_HE,             0});
     cols.push_back({ColumnType::RAD_HE_ERROR,       0});
     cols.push_back({ColumnType::RAD_HE3,            0});

--- a/src/gui/resultsmodel.cpp
+++ b/src/gui/resultsmodel.cpp
@@ -99,7 +99,7 @@ const QList<ExtendedColumnType> ResultsModel::GetAvailableColumnTypes() const //
         cols.push_back({ColumnType::MODEL_CONCENTRATION_ERROR, i});
     }
 
-    for (unsigned i = 0; i < 5; ++i) //WIPev1
+    for (unsigned i = 0; i < 5; ++i)
     {
         cols.push_back({ColumnType::MEASURED_CONCENTRATION,       i});
         cols.push_back({ColumnType::MEASURED_CONCENTRATION_ERROR, i});
@@ -344,7 +344,10 @@ double ResultsModel::GetDeltaNeon(const FitResults& results) const
         / results.equilibrium_concentrations.at(0).at(static_cast<GasType>(1)).value
         * 100;
 }
-double ResultsModel::GetDeltaNeonError(const FitResults& results) const //WIP: Fehlerrechnung anpassen (nicht unabhängig)
+double ResultsModel::GetDeltaNeonError(const FitResults& results) const
+// Fehlerrechnung hier ist nur Näherung (eigentlich nicht unabhängig) 
+// (Aber Ne Konzentration hat keine so starke Gewichtung für Bestimmung T und damit Ceq,
+// deswegen kann die Näherung verwendet werden)
 {
     return 
         std::sqrt

--- a/src/gui/resultsmodel.cpp
+++ b/src/gui/resultsmodel.cpp
@@ -65,7 +65,7 @@ QVariant ResultsModel::headerData(int section,
     return QVariant();
 }
 
-const QList<ExtendedColumnType> ResultsModel::GetAvailableColumnTypes() const
+const QList<ExtendedColumnType> ResultsModel::GetAvailableColumnTypes() const //Position gibt Reihenfolge
 {
     const unsigned n_covariances = (n_parameters_ * (n_parameters_ - 1) / 2);
     QList<ExtendedColumnType> cols;
@@ -106,7 +106,12 @@ const QList<ExtendedColumnType> ResultsModel::GetAvailableColumnTypes() const
     }
 
     cols.push_back({ColumnType::CHI, 0});
-
+    cols.push_back({ColumnType::DELTA_NEON,         1}); //WIP: 1 wird nicht verwendet
+    cols.push_back({ColumnType::DELTA_NEON_ERROR,   1});
+    cols.push_back({ColumnType::RAD_HE,             0});
+    cols.push_back({ColumnType::RAD_HE_ERROR,       0});
+    cols.push_back({ColumnType::RAD_HE3,            0});
+    cols.push_back({ColumnType::RAD_HE3_ERROR,      0});
     return cols;
 }
 
@@ -126,13 +131,13 @@ const QList<ExtendedColumnType> ResultsModel::GetDoubleColumnTypes() const
     return available_column_types;
 }
 
-QVariant ResultsModel::GetElement(
+QVariant ResultsModel::GetElement( //WIP: Für einen Column Type, welche werden alle abgefragt?
         const FitResults& results,
         const ExtendedColumnType& column_type) const
 {
     try
     {
-        unsigned i = column_type.second;
+        unsigned i = column_type.second; //Hier wird Gas gewählt
         switch (column_type.first)
         {
             case ColumnType::DEGREES_OF_FREEDOM:
@@ -169,6 +174,47 @@ QVariant ResultsModel::GetElement(
             }
             case ColumnType::RESIDUAL:
                 return GetResidualForGas(results, i);
+            case ColumnType::DELTA_NEON:
+                return GetDeltaNeon(results);
+            case ColumnType::DELTA_NEON_ERROR:
+                 return GetDeltaNeonError(results);
+            case ColumnType::RAD_HE:
+                return (results.measured_concentrations.at(0).at(                    
+                        static_cast<GasType>(0)).value
+                        - results.model_concentrations.at(0).at(
+                        static_cast<GasType>(0)).value);
+            case ColumnType::RAD_HE_ERROR:
+                return std::sqrt(
+                    std::pow(
+                        results.measured_concentrations.at(0).at(
+                        static_cast<GasType>(0)).error,
+                        2.0
+                    )
+                    + std::pow(
+                        results.model_concentrations.at(0).at(
+                        static_cast<GasType>(i)).error,
+                        2.0
+                    )
+                );
+            case ColumnType::RAD_HE3:
+                return 0.00000002*( //WIP: in physical properties!
+                        results.measured_concentrations.at(0).at(                    
+                        static_cast<GasType>(0)).value
+                        - results.model_concentrations.at(0).at(
+                        static_cast<GasType>(0)).value);
+            case ColumnType::RAD_HE3_ERROR: 
+                return 0.00000002*std::sqrt(
+                    std::pow(
+                        results.measured_concentrations.at(0).at(
+                        static_cast<GasType>(0)).error,
+                        2.0
+                    )
+                    + std::pow(
+                        results.model_concentrations.at(0).at(
+                        static_cast<GasType>(i)).error,
+                        2.0
+                    )
+                );
             case ColumnType::EQUILIBRIUM_CONCENTRATION:
                 return results.equilibrium_concentrations.at(0).at(
                         static_cast<GasType>(i)).value;
@@ -223,6 +269,18 @@ QString ResultsModel::GetColumnName(const ExtendedColumnType& type) const
         case ColumnType::RESIDUAL:
             return QString::fromStdString("Res_" +
                     Gas::GasTypeToString(GetGasFromIndex(i)));
+        case ColumnType::DELTA_NEON:
+            return "D_Ne [%]";
+        case ColumnType::DELTA_NEON_ERROR:
+            return "D_Ne_err [%]";
+        case ColumnType::RAD_HE:
+            return "Rad_He [ccSTP/g]";
+        case ColumnType::RAD_HE_ERROR:
+            return "Rad_He_err [ccSTP/g]";
+        case ColumnType::RAD_HE3:
+            return "Rad_³He [ccSTP/g]";
+        case ColumnType::RAD_HE3_ERROR:
+            return "Rad_³He_err [ccSTP/g]";
         case ColumnType::EQUILIBRIUM_CONCENTRATION:
         case ColumnType::EQUILIBRIUM_CONCENTRATION_ERROR:
         case ColumnType::MODEL_CONCENTRATION:
@@ -269,9 +327,38 @@ double ResultsModel::GetResidualForGas(const FitResults& results,
     GasType gas = GetGasFromIndex(gas_index);
     assert(results.residuals.size() == unsigned(results.residual_gases.size()));
     for (unsigned i = 0; i < results.residuals.size(); ++i)
-        if (results.residual_gases[i] == gas)
+        if (results.residual_gases[i] == gas) //WIP: Wofür brauche ich die Prüfung und brauche ich sie auch für DNe?
             return results.residuals[i];
     return std::numeric_limits<double>::quiet_NaN();
+}
+
+
+double ResultsModel::GetDeltaNeon(const FitResults& results) const
+{
+    //WIP: Prüfen ob es Neon gibt?
+    return 
+        (
+            results.measured_concentrations.at(0).at(static_cast<GasType>(1)).value
+            - results.equilibrium_concentrations.at(0).at(static_cast<GasType>(1)).value
+        )
+        / results.equilibrium_concentrations.at(0).at(static_cast<GasType>(1)).value
+        * 100;
+}
+double ResultsModel::GetDeltaNeonError(const FitResults& results) const //WIP: Fehlerrechnung anpassen (nicht unabhängig)
+{
+    return 
+        std::sqrt
+        (
+            std::pow(
+                results.measured_concentrations.at(0).at(static_cast<GasType>(1)).error
+                / results.measured_concentrations.at(0).at(static_cast<GasType>(1)).value, 2.)
+            + std::pow(
+                results.equilibrium_concentrations.at(0).at(static_cast<GasType>(1)).error
+                / results.equilibrium_concentrations.at(0).at(static_cast<GasType>(1)).value, 2.)
+        )
+        * results.measured_concentrations.at(0).at(static_cast<GasType>(1)).value
+        / results.equilibrium_concentrations.at(0).at(static_cast<GasType>(1)).value
+        *100 ;
 }
 
 GasType ResultsModel::GetGasFromIndex(unsigned i) const

--- a/src/gui/resultsmodel.h
+++ b/src/gui/resultsmodel.h
@@ -43,7 +43,13 @@ enum class ColumnType
     MODEL_CONCENTRATION_ERROR,
     MEASURED_CONCENTRATION,
     MEASURED_CONCENTRATION_ERROR,
-    CHI
+    CHI,
+    DELTA_NEON,
+    DELTA_NEON_ERROR,
+    RAD_HE,
+    RAD_HE_ERROR,
+    RAD_HE3,
+    RAD_HE3_ERROR,
 };
 
 typedef std::pair<ColumnType, unsigned> ExtendedColumnType;
@@ -73,6 +79,8 @@ protected:
                         const ExtendedColumnType& column_type) const;
     double GetResidualForGas(const FitResults& results,
                              unsigned gas_index) const;
+    double GetDeltaNeon(const FitResults& results) const;
+    double GetDeltaNeonError(const FitResults& results) const;             
     GasType GetGasFromIndex(unsigned i) const;
 
     //! \brief Durchläuft die Elemente der Oberen Dreiecksmatrix spaltenweise

--- a/src/gui/standardfitresultsmodel.cpp
+++ b/src/gui/standardfitresultsmodel.cpp
@@ -133,7 +133,7 @@ StandardFitResultsModel::GetResultsVector() const
     return results_;
 }
 
-bool StandardFitResultsModel::IsParameterInNormalRange( //WIPev2
+bool StandardFitResultsModel::IsParameterInNormalRange(
         const FitResults& results,
         const ExtendedColumnType& column_type) const //WIP: 0 Column Type
 {

--- a/src/gui/standardfitresultsmodel.cpp
+++ b/src/gui/standardfitresultsmodel.cpp
@@ -35,7 +35,7 @@ StandardFitResultsModel::StandardFitResultsModel(
             gases_in_use,
             parent),
     results_(std::make_shared<ResultsVector>()),
-    column_types_(GetAvailableColumnTypes()),
+    column_types_(GetAvailableColumnTypes()), //WIP: -2 Alle
     sample_needs_monte_carlo_initialized_(false)
 {
 }
@@ -80,7 +80,7 @@ QVariant StandardFitResultsModel::headerData(
     return QVariant();
 }
 
-QVariant StandardFitResultsModel::data(const QModelIndex& index, int role) const
+QVariant StandardFitResultsModel::data(const QModelIndex& index, int role) const //WIP: -1 Column-Types in index
 {
     if (index == QModelIndex()) return QVariant();
     try
@@ -89,7 +89,7 @@ QVariant StandardFitResultsModel::data(const QModelIndex& index, int role) const
         {
             case Qt::DisplayRole:
                 return GetElement(*results_->at(index.row()),
-                                  column_types_.at(index.column()));
+                                  column_types_.at(index.column())); //WIP: 0 Verwendete Column-Types
             case Qt::ForegroundRole:
                 return IsParameterInNormalRange(
                                *results_->at(index.row()),
@@ -133,9 +133,9 @@ StandardFitResultsModel::GetResultsVector() const
     return results_;
 }
 
-bool StandardFitResultsModel::IsParameterInNormalRange(
+bool StandardFitResultsModel::IsParameterInNormalRange( //WIPev2
         const FitResults& results,
-        const ExtendedColumnType& column_type) const
+        const ExtendedColumnType& column_type) const //WIP: 0 Column Type
 {
     unsigned i = column_type.second;
     switch (column_type.first)
@@ -171,7 +171,7 @@ bool StandardFitResultsModel::DoesSampleNeedMonteCarlo(
     {
         sample_needs_monte_carlo_.clear();
         sample_needs_monte_carlo_.resize(results_->size(), false);
-        for (const auto& column_type : column_types_)
+        for (const auto& column_type : column_types_) //WIP: -1 column_types
         {
             if (column_type.first != ColumnType::PARAMETER_ESTIMATE &&
                 column_type.first != ColumnType::PARAMETER_ESTIMATE_ERROR)

--- a/src/gui/standardfitresultsmodel.cpp
+++ b/src/gui/standardfitresultsmodel.cpp
@@ -35,7 +35,7 @@ StandardFitResultsModel::StandardFitResultsModel(
             gases_in_use,
             parent),
     results_(std::make_shared<ResultsVector>()),
-    column_types_(GetAvailableColumnTypes()), //WIP: -2 Alle
+    column_types_(GetAvailableColumnTypes()),
     sample_needs_monte_carlo_initialized_(false)
 {
 }
@@ -80,7 +80,7 @@ QVariant StandardFitResultsModel::headerData(
     return QVariant();
 }
 
-QVariant StandardFitResultsModel::data(const QModelIndex& index, int role) const //WIP: -1 Column-Types in index
+QVariant StandardFitResultsModel::data(const QModelIndex& index, int role) const 
 {
     if (index == QModelIndex()) return QVariant();
     try
@@ -89,7 +89,7 @@ QVariant StandardFitResultsModel::data(const QModelIndex& index, int role) const
         {
             case Qt::DisplayRole:
                 return GetElement(*results_->at(index.row()),
-                                  column_types_.at(index.column())); //WIP: 0 Verwendete Column-Types
+                                  column_types_.at(index.column()));
             case Qt::ForegroundRole:
                 return IsParameterInNormalRange(
                                *results_->at(index.row()),
@@ -135,7 +135,7 @@ StandardFitResultsModel::GetResultsVector() const
 
 bool StandardFitResultsModel::IsParameterInNormalRange(
         const FitResults& results,
-        const ExtendedColumnType& column_type) const //WIP: 0 Column Type
+        const ExtendedColumnType& column_type) const
 {
     unsigned i = column_type.second;
     switch (column_type.first)
@@ -171,7 +171,7 @@ bool StandardFitResultsModel::DoesSampleNeedMonteCarlo(
     {
         sample_needs_monte_carlo_.clear();
         sample_needs_monte_carlo_.resize(results_->size(), false);
-        for (const auto& column_type : column_types_) //WIP: -1 column_types
+        for (const auto& column_type : column_types_)
         {
             if (column_type.first != ColumnType::PARAMETER_ESTIMATE &&
                 column_type.first != ColumnType::PARAMETER_ESTIMATE_ERROR)

--- a/src/gui/testing/test_resultsmodel.cpp
+++ b/src/gui/testing/test_resultsmodel.cpp
@@ -42,34 +42,34 @@ using ::testing::Mock;
 
 BOOST_AUTO_TEST_SUITE(StandardFitResultsModel_tests)
 
-BOOST_AUTO_TEST_CASE(columnCount_2FitParameters5Gases_Return49)
+BOOST_AUTO_TEST_CASE(columnCount_2FitParameters5Gases_Return55)
 {
     StandardFitResultsModel model(
         {},
         {"A", "B"},
         {Gas::HE, Gas::NE, Gas::AR, Gas::KR, Gas::XE});
 
-    BOOST_CHECK_EQUAL(model.columnCount(), 49);
+    BOOST_CHECK_EQUAL(model.columnCount(), 55);
 }
 
-BOOST_AUTO_TEST_CASE(columnCount_5FitParameters5Gases_Return64)
+BOOST_AUTO_TEST_CASE(columnCount_5FitParameters5Gases_Return70)
 {
     StandardFitResultsModel model(
         {},
         {"A", "B", "C", "D", "E"},
         {Gas::HE, Gas::NE, Gas::AR, Gas::KR, Gas::XE});
 
-    BOOST_CHECK_EQUAL(model.columnCount(), 64);
+    BOOST_CHECK_EQUAL(model.columnCount(), 70);
 }
 
-BOOST_AUTO_TEST_CASE(columnCount_2FitParameters3Gases_Return47)
+BOOST_AUTO_TEST_CASE(columnCount_2FitParameters3Gases_Return53)
 {
     StandardFitResultsModel model(
         {},
         {"A", "B"},
         {Gas::NE, Gas::AR, Gas::XE});
 
-    BOOST_CHECK_EQUAL(model.columnCount(), 47);
+    BOOST_CHECK_EQUAL(model.columnCount(), 53);
 }
 
 BOOST_AUTO_TEST_CASE(data_InvalidModelIndex_ReturnInvalidQVariant)


### PR DESCRIPTION
### New Solubilities
New high precision noble gas solubilities from Jenkins et al. (2019)<sup>1</sup> have been added and are recommended to use. The previously used solubilities from Weiss combined with Clever are still available for comparison.

### Changes in the used Physical Properties
In accordance to upcoming publications in noble gas thermometry, some used physical properties were adjusted. 

* molar volume:  
Molar volumes based on Dymond and Smith (1980)<sup>2</sup> are used for the conversion of concentration units (mol/g) to (ccSTP/g). This also effects the solubilities from Clever. 
* water vapor pressure:  
The used water vapor pressure is based on Dickson et al. (2007)<sup>3</sup> (see also R. Hamme skript: vpress Version 2.0).

### Additional Output Data
* D_Ne: (C_meas(Ne)-C_eq(Ne))/C_eq(Ne)  
The uncertainty D_Ne_err is only approximated by propagation assuming independent variables.
* Rad_He: C_meas(He)-C_mod(He)
* Rad_³He: approximated by Rad_He*2E-8


<sup>1</sup> Jenkins et al., "A determination of atmospheric helium, neon, argon, krypton, and xenon solubility concentrations in water and seawater", 2019  
<sup>2</sup> Dymond and Smith, "The Virial Coefficients of Pure Gases and Mixtures", 1980  
<sup>3</sup> Dickson et al., "Guide to Best Practices for Ocean CO2 Measurements", 2007